### PR TITLE
disable vue built-in search filter

### DIFF
--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -17,6 +17,7 @@
         @input="makeSelection"
         auto-select-first
         autofocus
+        no-filter
     >
       <template v-slot:item="data">
         <v-list-item-icon>


### PR DESCRIPTION
Allows openalex api results to be displayed in autocomplete without filtering