### PR TITLE
inject docstrings into filter dialog boxes

### DIFF
--- a/src/components/FilterEdit/FilterEditBoolean.vue
+++ b/src/components/FilterEdit/FilterEditBoolean.vue
@@ -13,6 +13,8 @@
       </v-toolbar-items>
     </v-toolbar>
     <v-card-text class="pt-0">
+      {{ this.filterDocstrings[myConfig.key].docstring }} <a :href="this.filterDocstrings[myConfig.key].documentationLink" rel="noopener noreferrer" target="_blank">Learn more in the docs</a>
+      <br />
       <div>
         Show only {{ entityType | pluralize(1) }} that
         <span>
@@ -36,6 +38,7 @@
 
 import {mapActions, mapGetters, mapMutations} from "vuex";
 import {getFacetConfig} from "../../facetConfigs";
+import {api} from "@/api";
 
 export default {
   name: "FilterEditBoolean",
@@ -49,6 +52,7 @@ export default {
     return {
       foo: 42,
       myValue: (this.createMode) ? true : this.filterValue,
+      filterDocstrings: [],
     }
   },
   computed: {
@@ -74,7 +78,8 @@ export default {
   },
   created() {
   },
-  mounted() {
+  async mounted() {
+    this.filterDocstrings = await api.get("works/filters_docstrings")
   },
   watch: {}
 }

--- a/src/components/FilterEdit/FilterEditRange.vue
+++ b/src/components/FilterEdit/FilterEditRange.vue
@@ -17,7 +17,7 @@
 
     </v-toolbar>
     <v-card-text>
-      Here's some information about this filter.
+      {{ this.filterDocstrings[myConfig.key].docstring }} <a :href="this.filterDocstrings[myConfig.key].documentationLink" rel="noopener noreferrer" target="_blank">Learn more in the docs</a>
     </v-card-text>
     <v-card-actions>
       <v-spacer/>
@@ -33,6 +33,7 @@
 
 import {mapActions, mapGetters, mapMutations} from "vuex";
 import {getFacetConfig} from "../../facetConfigs";
+import {api} from "@/api";
 
 export default {
   name: "FilterEditRange",
@@ -46,6 +47,7 @@ export default {
     return {
       foo: 42,
       myValue: this.filterValue,
+      filterDocstrings: [],
     }
   },
   computed: {
@@ -68,7 +70,8 @@ export default {
   },
   created() {
   },
-  mounted() {
+  async mounted() {
+    this.filterDocstrings = await api.get("works/filters_docstrings")
   },
   watch: {}
 }

--- a/src/components/FilterEdit/FilterEditSearch.vue
+++ b/src/components/FilterEdit/FilterEditSearch.vue
@@ -15,7 +15,7 @@
     </v-toolbar>
     <v-divider></v-divider>
     <v-card-text class="pt-4">
-      Here are a few words about this filter.
+      {{ this.filterDocstrings[myConfig.key].docstring }} <a :href="this.filterDocstrings[myConfig.key].documentationLink" rel="noopener noreferrer" target="_blank">Learn more in the docs</a>
     </v-card-text>
     <v-card-actions>
       <v-spacer/>
@@ -31,6 +31,7 @@
 
 import {mapActions, mapGetters, mapMutations} from "vuex";
 import {getFacetConfig} from "../../facetConfigs";
+import {api} from "@/api";
 
 export default {
   name: "FilterEditSearch",
@@ -44,6 +45,7 @@ export default {
     return {
       foo: 42,
       myValue: this.filterValue,
+      filterDocstrings: [],
     }
   },
   computed: {
@@ -69,7 +71,8 @@ export default {
   },
   created() {
   },
-  mounted() {
+  async mounted() {
+    this.filterDocstrings = await api.get("works/filters_docstrings")
   },
   watch: {}
 }

--- a/src/components/FilterEdit/FilterEditSelect.vue
+++ b/src/components/FilterEdit/FilterEditSelect.vue
@@ -14,7 +14,7 @@
     </div>
     <v-divider></v-divider>
     <v-card-text class="pt-4" v-if="!selectedOptionsToShow.length && !searchString">
-      Here's some information about this filter. I hope you find it useful.
+      {{ this.filterDocstrings[myConfig.key].docstring }} <a :href="this.filterDocstrings[myConfig.key].documentationLink" rel="noopener noreferrer" target="_blank">Learn more in the docs</a>
     </v-card-text>
     <v-list
     >
@@ -119,6 +119,7 @@ export default {
       selectedMatchMode: "any",
       searchString: "",
       mySelectedValues: [],
+      filterDocstrings: [],
     }
   },
   computed: {
@@ -135,7 +136,7 @@ export default {
     },
     selectedOptionsToShow() {
       return this.searchString ? [] : this.selectedOptions
-    }
+    },
   },
 
   methods: {
@@ -228,6 +229,7 @@ export default {
           autocompletePromises
       )
     }
+    this.filterDocstrings = await api.get("works/filters_docstrings")
   },
   watch: {
     searchString: {


### PR DESCRIPTION
Docstrings for filters (only works filters so far) are available at the api endpoint https://api.openalex.org/works/filters_docstrings. This method will request those docstrings and inject them into the filter dialog boxes. 

This may not be the cleanest way to do it; maybe it should be moved to the Vuex store.