### PR TITLE
fixed pagination bug and added option of 25 results to the UI 

### DIFF
--- a/src/components/SerpResultsList.vue
+++ b/src/components/SerpResultsList.vue
@@ -1,22 +1,19 @@
 <template>
   <div>
     <v-toolbar dense flat class="" color="transparent">
-<!--      <v-icon left>mdi-checkbox-blank-outline</v-icon>-->
+      <!--      <v-icon left>mdi-checkbox-blank-outline</v-icon>-->
       <v-toolbar-title class="font-weight-bold mr-2">
         {{ entityType | pluralize(2) | capitalize }}
-<!--       (<serp-results-count :results-object="resultsObject" class=""/>)-->
+        <!--       (<serp-results-count :results-object="resultsObject" class=""/>)-->
       </v-toolbar-title>
-      <v-spacer/>
-<!--      <action class="ml-2" action="sort"/>-->
+      <v-spacer />
+      <!--      <action class="ml-2" action="sort"/>-->
       <serp-results-sort-button />
 
       <serp-results-export-button />
       <v-menu offset-y rounded>
         <template v-slot:activator="{on}">
-          <v-btn
-            v-on="on"
-            icon
-          >
+          <v-btn v-on="on" icon>
             <v-icon>mdi-dots-vertical</v-icon>
           </v-btn>
         </template>
@@ -27,6 +24,14 @@
               <v-list-item-title>10</v-list-item-title>
             </v-list-item-content>
             <v-list-item-icon v-if="url.getPerPage($route) === 10">
+              <v-icon>mdi-check</v-icon>
+            </v-list-item-icon>
+          </v-list-item>
+          <v-list-item @click="url.setPerPage(25)">
+            <v-list-item-content>
+              <v-list-item-title>25</v-list-item-title>
+            </v-list-item-content>
+            <v-list-item-icon v-if="url.getPerPage($route) === 25">
               <v-icon>mdi-check</v-icon>
             </v-list-item-icon>
           </v-list-item>
@@ -42,34 +47,23 @@
       </v-menu>
     </v-toolbar>
 
-  <v-card rounded flat class="">
+    <v-card rounded flat class="">
 
-<!--      <div class="grey&#45;&#45;text">-->
-<!--        <serp-results-count :results-object="resultsObject" class="ml-4"/>-->
-<!--      </div>-->
-    <v-list nav v-if="resultsObject?.results" class="" color="">
-      <serp-results-list-item
-        v-for="result in resultsObject.results"
-        :key="result.id"
-        :result="result"
-        show-icon
-      />
+      <!--      <div class="grey&#45;&#45;text">-->
+      <!--        <serp-results-count :results-object="resultsObject" class="ml-4"/>-->
+      <!--      </div>-->
+      <v-list nav v-if="resultsObject?.results" class="" color="">
+        <serp-results-list-item v-for="result in resultsObject.results" :key="result.id" :result="result" show-icon />
 
-    </v-list>
-    <div class="serp-bottom" v-if="resultsObject?.results?.length">
-      <v-pagination
-          class="pb-8 pt-3 elevation-0"
-          circle
-          v-model="page"
-          :length="numPages"
-          :total-visible="10"
-          light
-      />
-    </div>
-    <v-card v-if="!resultsObject?.meta?.count" flat rounded class="grey--text mt-2 pa-4 color-3">
-      There are no results for this search.
+      </v-list>
+      <div class="serp-bottom" v-if="resultsObject?.results?.length">
+        <v-pagination class="pb-8 pt-3 elevation-0" circle v-model="page" :length="numPages"
+          :total-visible="totalVisible" light />
+      </div>
+      <v-card v-if="!resultsObject?.meta?.count" flat rounded class="grey--text mt-2 pa-4 color-3">
+        There are no results for this search.
+      </v-card>
     </v-card>
-  </v-card>
   </div>
 </template>
 
@@ -104,7 +98,7 @@ export default {
     return {
       foo: 42,
       url,
-      resultsPerPage: 10, // not editable now, but could be in future
+      resultsPerPage: 25, // not editable now, but could be in future
     }
   },
   computed: {
@@ -112,15 +106,11 @@ export default {
       "resultsFilters",
       "entityType",
     ]),
+    totalVisible() {
+      return this.$vuetify.breakpoint.mobile ? 4 : 10
+    },
     numPages() {
-      const maxToShow = this.$vuetify.breakpoint.mobile ?
-          4 :
-          10
-
-      return Math.min(
-          Math.ceil(this.resultsObject.meta.count / this.resultsPerPage),
-          maxToShow
-      )
+      return Math.ceil(this.resultsObject.meta.count / url.getPerPage(this.$route))
     },
     page: {
       get() {

--- a/src/url.js
+++ b/src/url.js
@@ -565,7 +565,7 @@ const toggleSort = function (filterKey) {
 }
 
 
-const perPageDefault = 10
+const perPageDefault = 25;
 const setPerPage = function(val){
     const perPage = val === perPageDefault ?
         undefined :


### PR DESCRIPTION
# Description:
The changes in this pull request aim to address pagination display issues where only 10 pages were consistently shown. Additionally, the default number of items per page has been updated to match the items displayed in the UI. Furthermore, the "Results per page" menu has been enhanced to include the option for displaying 25 items per page alongside the existing options. These adjustments aim to fix the pagination issue where not all pages were being displayed properly.

### Before:
![image](https://github.com/ourresearch/openalex-gui/assets/60817875/484dafcc-abe7-4f42-89fd-33d9181e5a3f)


### After:
![image](https://github.com/ourresearch/openalex-gui/assets/60817875/a061775c-a8a3-465d-8efe-ec15258088fb)


## Changes Made:
### Updated Default Items Per Page:

- Changed the default number of items per page from 10 to 25 to better match the default display in the UI.

### Improved Pagination Calculation:
- Refactored the `numPages()` method to calculate the total number of pages based on the current count of results and the selected number of items per page. This ensures accurate pagination irrespective of the chosen number of items per page.
### Adjusted Total Visible Pages:
- Implemented a new function `totalVisible()` to dynamically set the total visible pages based on the screen size, ensuring consistent and optimal display of pagination controls.
### Enhanced Results Per Page Menu:
- Updated "the results per page menu" to reflect the change in default value and added visual indication (checkmark) for the selected option. the menu now includes the option for 25 items per page alongside the existing options for 10 and 100.
## Additional Notes:
- These changes have been tested locally and verified to work as expected.

- Note that if you attempt to display a page with records beyond the maximum size of 10,000, an error will be received from the API. Maximum results size of 10,000 records is exceeded. Cursor pagination is required for records beyond 10,000. See: https://docs.openalex.org/api#cursor-paging
