### PR TITLE
Add author profile curation feature behind feature flag

### DIFF
--- a/src/apiConfig.js
+++ b/src/apiConfig.js
@@ -14,6 +14,7 @@ const urlBase = {
     api: "https://api.openalex.org",
     userApi: "https://user.openalex.org",
     correctionsApi: "https://corrections.openalex.org",
+    cvParseApi: "https://api.openalex.org",  // CV parsing proxy (server-side Claude calls)
 };
 
 // Use port to change local API endpoints
@@ -41,10 +42,12 @@ if (window.location.port && parseInt(window.location.port) === 8081) {
     urlBase.userApi = "http://localhost:5106";
     console.log("Setting User API base URL to local machine (dev use only): " + urlBase.userApi);
 
-// 8085: Local Corrections API
+// 8085: Local Corrections API + CV Parse Server
 } else if (window.location.port && parseInt(window.location.port) === 8085) {
     urlBase.correctionsApi = "http://localhost:5006";
     console.log("Setting Corrections API base URL to local machine (dev use only): " + urlBase.correctionsApi);
+    urlBase.cvParseApi = "http://localhost:3456";
+    console.log("Setting CV Parse API base URL to local machine (dev use only): " + urlBase.cvParseApi);
 }
 
 const axiosConfig = (options={}) => {

--- a/src/components/AuthorCuration/AddWorksCVUpload.vue
+++ b/src/components/AuthorCuration/AddWorksCVUpload.vue
@@ -1,0 +1,560 @@
+<template>
+  <div class="cv-upload">
+    <div class="text-body-2 text-medium-emphasis mb-4">
+      Upload your CV or publication list and we'll match your publications to OpenAlex records.
+      Supported formats: .txt, .pdf, .doc, .docx
+    </div>
+
+    <!-- Upload zone (hide after results) -->
+    <template v-if="!parseResults">
+      <div
+        class="upload-zone"
+        :class="{ 'upload-zone--dragover': isDragOver }"
+        @dragover.prevent="isDragOver = true"
+        @dragleave="isDragOver = false"
+        @drop.prevent="handleDrop"
+        @click="triggerFileInput"
+      >
+        <v-icon size="40" color="grey-lighten-1" class="mb-2">mdi-file-upload-outline</v-icon>
+        <div class="text-body-2">
+          Drag and drop your file here, or <span class="text-primary" style="cursor: pointer">browse</span>
+        </div>
+        <div class="text-caption text-medium-emphasis mt-1">
+          .txt, .pdf, .doc, .docx
+        </div>
+      </div>
+
+      <input
+        ref="fileInput"
+        type="file"
+        accept=".txt,.pdf,.doc,.docx"
+        style="display: none"
+        @change="handleFileSelect"
+      />
+
+      <!-- Selected file -->
+      <div v-if="selectedFile" class="selected-file mt-3 d-flex align-center">
+        <v-icon size="18" class="mr-2">mdi-file-document-outline</v-icon>
+        <span class="text-body-2">{{ selectedFile.name }}</span>
+        <v-spacer />
+        <v-btn icon variant="text" size="x-small" @click="selectedFile = null">
+          <v-icon size="16">mdi-close</v-icon>
+        </v-btn>
+      </div>
+
+      <!-- Upload button -->
+      <div v-if="selectedFile && !isProcessing" class="mt-4">
+        <v-btn color="primary" variant="flat" rounded :loading="isProcessing" @click="processFile">
+          Parse publications
+        </v-btn>
+      </div>
+
+      <!-- Processing -->
+      <div v-if="isProcessing" class="mt-4 d-flex align-center text-body-2 text-medium-emphasis">
+        <v-progress-circular indeterminate size="20" width="2" class="mr-3" />
+        {{ currentLoadingMessage }}
+      </div>
+
+      <!-- Error -->
+      <v-alert v-if="errorMessage" type="error" variant="tonal" class="mt-4 text-body-2">
+        {{ errorMessage }}
+      </v-alert>
+    </template>
+
+    <!-- Results -->
+    <div v-if="parseResults" class="parse-results">
+      <!-- Summary -->
+      <div class="parse-summary mb-2">
+        <div class="text-body-1 font-weight-bold">
+          Parsed {{ parseResults.totalParsed }} publications from your CV
+        </div>
+      </div>
+
+      <!-- Tabs for results categories -->
+      <v-tabs v-model="resultsTab" density="compact">
+        <v-tab value="addable" class="cv-tab cv-tab--addable">
+          <v-icon size="14" start class="mr-1" color="#4CAF50">mdi-plus-circle</v-icon>
+          Add ({{ addableWorks.length }})
+        </v-tab>
+        <v-tab value="linked" class="cv-tab cv-tab--linked">
+          <v-icon size="14" start class="mr-1" color="grey">mdi-check-circle</v-icon>
+          Already matched ({{ alreadyLinkedCount }})
+        </v-tab>
+        <v-tab value="unmatched" class="cv-tab cv-tab--unmatched">
+          <v-icon size="14" start class="mr-1" color="#FF9800">mdi-help-circle</v-icon>
+          Not found ({{ parseResults.unmatched.length }})
+        </v-tab>
+      </v-tabs>
+
+      <v-divider />
+
+      <v-window v-model="resultsTab">
+        <!-- Works to add -->
+        <v-window-item value="addable">
+          <div v-if="addableWorks.length === 0" class="pa-4 text-body-2 text-medium-emphasis">
+            No new works to add from your CV.
+          </div>
+          <div v-else>
+            <div
+              v-for="(item, idx) in addableWorks"
+              :key="idx"
+              class="cv-result-item"
+              :class="{ 'cv-result-item--selected': item._isSelected }"
+            >
+              <div class="d-flex align-start">
+                <!-- Checkbox -->
+                <v-checkbox
+                  v-model="item._isSelected"
+                  hide-details
+                  density="compact"
+                  class="cv-result-checkbox mt-0 pt-0 mr-2"
+                  :disabled="!item._authorshipConfirmed"
+                />
+
+                <div class="flex-grow-1">
+                  <div class="text-body-2 font-weight-medium">
+                    {{ item.oaWork.display_name }}
+                  </div>
+                  <div class="text-caption text-medium-emphasis">
+                    {{ item.oaWork.publication_year }}
+                    <span v-if="item.oaWork.primary_location?.source?.display_name">
+                      · <span class="font-italic">{{ item.oaWork.primary_location.source.display_name }}</span>
+                    </span>
+                  </div>
+
+                  <!-- Authorship matching: show candidate names -->
+                  <div class="mt-2" v-if="item._matchState !== 'added'">
+                    <template v-if="item._candidateAuthorships && item._candidateAuthorships.length > 0">
+                      <div class="text-caption text-medium-emphasis mb-1">Select your name on this work:</div>
+                      <div class="d-flex flex-wrap ga-1">
+                        <v-chip
+                          v-for="(candidate, cidx) in item._candidateAuthorships"
+                          :key="cidx"
+                          size="small"
+                          :variant="item._selectedIdx === candidate.idx ? 'flat' : 'outlined'"
+                          :color="item._selectedIdx === candidate.idx ? 'primary' : undefined"
+                          @click="selectCvAuthorship(item, candidate.idx)"
+                        >
+                          {{ candidate.authorship.raw_author_name || candidate.authorship.author?.display_name || 'Unknown' }}
+                        </v-chip>
+                      </div>
+                      <div class="text-caption text-medium-emphasis mt-1">
+                        Not listed?
+                        <a href="#" @click.prevent="showCvAllAuthors(item)" class="text-primary">Show all authors</a>
+                        ·
+                        <a href="mailto:support@openalex.org">Contact support</a>
+                      </div>
+                    </template>
+
+                    <template v-else-if="item._showAllAuthors">
+                      <div class="text-caption text-medium-emphasis mb-1">Select your name:</div>
+                      <div class="d-flex flex-wrap ga-1">
+                        <v-chip
+                          v-for="(authorship, aidx) in item.oaWork.authorships"
+                          :key="aidx"
+                          size="small"
+                          :variant="item._selectedIdx === aidx ? 'flat' : 'outlined'"
+                          :color="item._selectedIdx === aidx ? 'primary' : undefined"
+                          @click="selectCvAuthorship(item, aidx)"
+                        >
+                          {{ authorship.raw_author_name || authorship.author?.display_name || 'Unknown' }}
+                        </v-chip>
+                      </div>
+                      <div class="text-caption text-medium-emphasis mt-1">
+                        Not here? <a href="mailto:support@openalex.org">Contact support</a>
+                      </div>
+                    </template>
+                  </div>
+
+                  <div v-else class="mt-1">
+                    <span class="text-caption" style="color: #2E7D32;">
+                      <v-icon size="14" color="success" class="mr-1">mdi-check-circle</v-icon>
+                      Curation request submitted
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Sticky footer for CV add tab -->
+            <div v-if="cvSelectedCount > 0" class="cv-add-footer">
+              <v-divider />
+              <div class="cv-add-footer-content">
+                <span class="text-body-2">
+                  {{ cvSelectedCount }} work{{ cvSelectedCount === 1 ? '' : 's' }} selected
+                </span>
+                <v-btn
+                  color="primary"
+                  variant="flat"
+                  rounded
+                  size="small"
+                  @click="submitCvSelectedWorks"
+                >
+                  Add works
+                </v-btn>
+              </div>
+            </div>
+          </div>
+        </v-window-item>
+
+        <!-- Already on profile (grey) -->
+        <v-window-item value="linked">
+          <div v-if="alreadyLinkedCount === 0" class="pa-4 text-body-2 text-medium-emphasis">
+            No works from your CV are already on your profile.
+          </div>
+          <div v-else>
+            <div
+              v-for="(item, idx) in alreadyLinked"
+              :key="'linked-' + idx"
+              class="cv-result-item cv-result-item--linked"
+            >
+              <v-icon size="14" color="grey" class="mr-2">mdi-check-circle</v-icon>
+              <div>
+                <span class="text-body-2">{{ item.oaWork.display_name }}</span>
+                <span class="text-caption text-medium-emphasis ml-1">{{ item.oaWork.publication_year }}</span>
+              </div>
+            </div>
+          </div>
+        </v-window-item>
+
+        <!-- Not found in OpenAlex (orange) -->
+        <v-window-item value="unmatched">
+          <div v-if="parseResults.unmatched.length === 0" class="pa-4 text-body-2 text-medium-emphasis">
+            All publications were found in OpenAlex.
+          </div>
+          <div v-else>
+            <div
+              v-for="(pub, idx) in parseResults.unmatched"
+              :key="'unmatched-' + idx"
+              class="cv-result-item cv-result-item--unmatched"
+            >
+              <v-icon size="14" color="warning" class="mr-2">mdi-alert-circle-outline</v-icon>
+              <div>
+                <span class="text-body-2">{{ pub.title }}</span>
+                <span v-if="pub.year" class="text-caption text-medium-emphasis ml-1">({{ pub.year }})</span>
+              </div>
+            </div>
+          </div>
+        </v-window-item>
+      </v-window>
+
+      <!-- Start over -->
+      <div class="mt-4">
+        <v-btn variant="text" rounded size="small" @click="resetResults">
+          Upload a different file
+        </v-btn>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onBeforeUnmount } from 'vue';
+import axios from 'axios';
+import { urlBase, axiosConfig } from '@/apiConfig';
+
+defineOptions({ name: 'AddWorksCVUpload' });
+
+// Fun rotating loading messages
+const loadingMessages = [
+  'Parsing your publications...',
+  'Searching the scholarly record...',
+  'Matching titles across almost 500M works...',
+  'Your CV is impressive, by the way...',
+  'Cross-referencing with OpenAlex...',
+  'Almost there — double-checking matches...',
+  'Reading between the lines (literally)...',
+  'Connecting the dots across databases...',
+  'Doing in seconds what used to take librarians hours...',
+  'Teaching an AI to read your CV — one publication at a time...',
+  'Sifting through the world\'s research...',
+  'If only peer review were this fast...',
+];
+
+const currentLoadingMessage = ref(loadingMessages[0]);
+let loadingInterval = null;
+
+function startLoadingMessages() {
+  let lastIdx = 0;
+  currentLoadingMessage.value = loadingMessages[0];
+  loadingInterval = setInterval(() => {
+    let idx;
+    do {
+      idx = Math.floor(Math.random() * loadingMessages.length);
+    } while (idx === lastIdx);
+    lastIdx = idx;
+    currentLoadingMessage.value = loadingMessages[idx];
+  }, 4000);
+}
+
+function stopLoadingMessages() {
+  if (loadingInterval) {
+    clearInterval(loadingInterval);
+    loadingInterval = null;
+  }
+}
+
+onBeforeUnmount(() => stopLoadingMessages());
+
+const props = defineProps({
+  authorName: String,
+  authorId: String,
+});
+
+const emit = defineEmits(['add-work']);
+
+const fileInput = ref(null);
+const selectedFile = ref(null);
+const isDragOver = ref(false);
+const isProcessing = ref(false);
+const parseResults = ref(null);
+const errorMessage = ref('');
+const resultsTab = ref('addable');
+
+const allowedExtensions = ['.txt', '.pdf', '.doc', '.docx'];
+
+// CV parse server URL — uses proxy server (local dev or production)
+const CV_PARSE_URL = `${urlBase.cvParseApi}/api/parse-cv`;
+
+function isValidFile(file) {
+  const ext = '.' + file.name.split('.').pop().toLowerCase();
+  return allowedExtensions.includes(ext);
+}
+
+function triggerFileInput() {
+  fileInput.value?.click();
+}
+
+function handleFileSelect(event) {
+  const file = event.target.files?.[0];
+  if (file && isValidFile(file)) {
+    selectedFile.value = file;
+    parseResults.value = null;
+    errorMessage.value = '';
+  }
+}
+
+function handleDrop(event) {
+  isDragOver.value = false;
+  const file = event.dataTransfer.files?.[0];
+  if (file && isValidFile(file)) {
+    selectedFile.value = file;
+    parseResults.value = null;
+    errorMessage.value = '';
+  }
+}
+
+function normalizeName(name) {
+  if (!name) return '';
+  let n = name.trim();
+  if (n.includes(',')) {
+    const parts = n.split(',').map(p => p.trim());
+    n = parts.reverse().join(' ');
+  }
+  return n.toLowerCase().replace(/[^a-z ]/g, '').replace(/\s+/g, ' ').trim();
+}
+
+function nameSimilarity(name1, name2) {
+  if (!name1 || !name2) return 0;
+  const a = normalizeName(name1);
+  const b = normalizeName(name2);
+  if (a === b) return 1;
+  const aWords = a.split(' ');
+  const bWords = b.split(' ');
+  const aLast = aWords[aWords.length - 1];
+  const bLast = bWords[bWords.length - 1];
+  if (aLast !== bLast) return 0;
+  const aFirst = aWords[0] || '';
+  const bFirst = bWords[0] || '';
+  if (aFirst === bFirst) return 1;
+  if (aFirst.startsWith(bFirst) || bFirst.startsWith(aFirst)) return 0.9;
+  if (aFirst[0] === bFirst[0]) return 0.7;
+  return 0.6;
+}
+
+function findCandidateAuthorships(work) {
+  if (!work.authorships || work.authorships.length === 0) return [];
+  const candidates = [];
+  work.authorships.forEach((authorship, idx) => {
+    const score = Math.max(
+      nameSimilarity(props.authorName, authorship.raw_author_name || ''),
+      nameSimilarity(props.authorName, authorship.author?.display_name || '')
+    );
+    if (score >= 0.6) {
+      candidates.push({ idx, authorship, score });
+    }
+  });
+  return candidates.sort((a, b) => b.score - a.score);
+}
+
+const alreadyLinked = computed(() =>
+  parseResults.value?.matched?.filter(m => m.alreadyLinked) || []
+);
+
+const alreadyLinkedCount = computed(() => alreadyLinked.value.length);
+
+const addableWorks = computed(() =>
+  parseResults.value?.matched?.filter(m => !m.alreadyLinked) || []
+);
+
+async function processFile() {
+  if (!selectedFile.value) return;
+  isProcessing.value = true;
+  errorMessage.value = '';
+  startLoadingMessages();
+
+  try {
+    const formData = new FormData();
+    formData.append('file', selectedFile.value);
+    formData.append('authorId', props.authorId || '');
+    formData.append('authorName', props.authorName || '');
+
+    const authHeaders = axiosConfig({ userAuth: true }).headers || {};
+    const resp = await axios.post(CV_PARSE_URL, formData, {
+      headers: { ...authHeaders, 'Content-Type': 'multipart/form-data' },
+      timeout: 120000, // 2 min timeout for large CVs
+    });
+
+    const data = resp.data;
+
+    // Run authorship matching on addable works (same UX as search)
+    data.matched.forEach(item => {
+      if (!item.alreadyLinked) {
+        const candidates = findCandidateAuthorships(item.oaWork);
+        item._candidateAuthorships = candidates;
+        item._showAllAuthors = candidates.length === 0;
+        item._isSelected = false;
+        item._authorshipConfirmed = false;
+        item._matchState = 'pending';
+
+        // Auto-select if exactly one strong match
+        if (candidates.length === 1 && candidates[0].score >= 0.7) {
+          item._selectedIdx = candidates[0].idx;
+          item._authorshipConfirmed = true;
+          item._isSelected = true;
+        } else {
+          item._selectedIdx = null;
+        }
+      }
+    });
+
+    parseResults.value = data;
+  } catch (err) {
+    console.error('CV parse error:', err);
+    errorMessage.value = err.response?.data?.error || 'Failed to parse CV. Please try again.';
+  } finally {
+    stopLoadingMessages();
+    isProcessing.value = false;
+  }
+}
+
+function showCvAllAuthors(item) {
+  item._showAllAuthors = true;
+  item._candidateAuthorships = [];
+}
+
+function selectCvAuthorship(item, idx) {
+  item._selectedIdx = idx;
+  item._authorshipConfirmed = true;
+  item._isSelected = true;
+}
+
+const cvSelectedCount = computed(() =>
+  addableWorks.value.filter(w => w._isSelected && w._authorshipConfirmed).length
+);
+
+function submitCvSelectedWorks() {
+  const selected = addableWorks.value.filter(w => w._isSelected && w._authorshipConfirmed);
+  selected.forEach(item => {
+    const authorship = item.oaWork.authorships[item._selectedIdx];
+    item._matchState = 'added';
+    emit('add-work', {
+      workId: item.oaWork.id,
+      authorshipIdx: item._selectedIdx,
+      authorship,
+    });
+  });
+}
+
+function resetResults() {
+  parseResults.value = null;
+  selectedFile.value = null;
+  errorMessage.value = '';
+  if (fileInput.value) fileInput.value.value = '';
+}
+</script>
+
+<style scoped>
+.upload-zone {
+  border: 2px dashed #E0E0E0;
+  border-radius: 12px;
+  padding: 40px 24px;
+  text-align: center;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.upload-zone:hover {
+  border-color: #BDBDBD;
+  background: #FAFAFA;
+}
+
+.upload-zone--dragover {
+  border-color: rgb(var(--v-theme-primary));
+  background: rgba(var(--v-theme-primary), 0.04);
+}
+
+.selected-file {
+  padding: 8px 12px;
+  background: #F5F5F5;
+  border-radius: 8px;
+}
+
+.parse-summary {
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.cv-result-item {
+  padding: 10px 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.cv-result-item:last-child {
+  border-bottom: none;
+}
+
+.cv-result-item--selected {
+  background: rgba(var(--v-theme-primary), 0.04);
+}
+
+.cv-result-checkbox {
+  flex-shrink: 0;
+}
+
+.cv-result-item--linked {
+  display: flex;
+  align-items: flex-start;
+  color: rgba(0, 0, 0, 0.5);
+}
+
+.cv-result-item--unmatched {
+  display: flex;
+  align-items: flex-start;
+  color: rgba(0, 0, 0, 0.5);
+}
+
+.cv-add-footer {
+  position: sticky;
+  bottom: 0;
+  background: white;
+  z-index: 1;
+}
+
+.cv-add-footer-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 0;
+}
+</style>

--- a/src/components/AuthorCuration/AddWorksDialog.vue
+++ b/src/components/AuthorCuration/AddWorksDialog.vue
@@ -1,0 +1,83 @@
+<template>
+  <v-dialog v-model="dialogOpen" max-width="720" scrollable persistent>
+    <v-card rounded>
+      <v-card-title class="d-flex align-center justify-space-between">
+        Add works to your profile
+        <v-btn icon variant="text" size="small" @click="close">
+          <v-icon>mdi-close</v-icon>
+        </v-btn>
+      </v-card-title>
+
+      <v-tabs v-model="activeTab" bg-color="transparent">
+        <v-tab value="search">Search OpenAlex</v-tab>
+        <v-tab value="upload">Upload CV</v-tab>
+      </v-tabs>
+
+      <v-divider />
+
+      <v-card-text class="pt-4" style="min-height: 400px; max-height: 70vh; overflow-y: auto;">
+        <v-window v-model="activeTab">
+          <v-window-item value="search">
+            <AddWorksSearch
+              :author-name="authorName"
+              :author-id="authorId"
+              @add-work="handleAddWork"
+            />
+          </v-window-item>
+
+          <v-window-item value="upload">
+            <AddWorksCVUpload
+              :author-name="authorName"
+              :author-id="authorId"
+            />
+          </v-window-item>
+        </v-window>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue';
+import AddWorksSearch from './AddWorksSearch.vue';
+import AddWorksCVUpload from './AddWorksCVUpload.vue';
+
+defineOptions({ name: 'AddWorksDialog' });
+
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    default: false,
+  },
+  authorName: {
+    type: String,
+    default: '',
+  },
+  authorId: {
+    type: String,
+    default: '',
+  },
+});
+
+const emit = defineEmits(['update:modelValue', 'add-work']);
+
+const dialogOpen = ref(props.modelValue);
+const activeTab = ref('search');
+
+watch(() => props.modelValue, (val) => {
+  dialogOpen.value = val;
+});
+
+watch(dialogOpen, (val) => {
+  emit('update:modelValue', val);
+});
+
+function close() {
+  dialogOpen.value = false;
+  activeTab.value = 'search';
+}
+
+function handleAddWork(workData) {
+  emit('add-work', workData);
+}
+</script>

--- a/src/components/AuthorCuration/AddWorksSearch.vue
+++ b/src/components/AuthorCuration/AddWorksSearch.vue
@@ -1,0 +1,445 @@
+<template>
+  <div class="add-works-search">
+    <!-- Search input -->
+    <v-text-field
+      v-model="searchQuery"
+      placeholder="Search by title, DOI, or author name"
+      variant="outlined"
+      density="compact"
+      hide-details
+      prepend-inner-icon="mdi-magnify"
+      :loading="isSearching"
+      @keydown.enter="doSearch"
+      clearable
+      @click:clear="clearResults"
+      class="mb-3"
+    />
+
+    <div v-if="!results.length && !isSearching && !hasSearched" class="text-body-2 text-medium-emphasis">
+      Search for works to add to your author profile. You can search by title, DOI, or author name.
+    </div>
+
+    <!-- Loading -->
+    <div v-if="isSearching" class="d-flex align-center text-body-2 text-medium-emphasis pa-4">
+      <v-progress-circular indeterminate size="20" width="2" class="mr-3" />
+      Searching works...
+    </div>
+
+    <!-- Already on profile -->
+    <div v-if="alreadyOnProfile && !isSearching" class="text-body-2 text-medium-emphasis pa-4">
+      <v-icon size="18" class="mr-1" color="primary">mdi-check-circle-outline</v-icon>
+      This work is already on your author profile.
+    </div>
+
+    <!-- No results -->
+    <div v-else-if="hasSearched && !isSearching && results.length === 0" class="text-body-2 text-medium-emphasis pa-4">
+      <v-icon size="18" class="mr-1">mdi-file-search-outline</v-icon>
+      No works found. Try a different search.
+    </div>
+
+    <!-- Results -->
+    <div v-if="results.length > 0" class="search-results">
+      <div class="text-caption text-medium-emphasis mb-2">
+        {{ totalResults.toLocaleString() }} result{{ totalResults === 1 ? '' : 's' }} found
+      </div>
+
+      <div
+        v-for="work in results"
+        :key="work.id"
+        class="search-result-item"
+        :class="{ 'search-result-item--selected': work._isSelected }"
+      >
+        <div class="d-flex align-start">
+          <!-- Checkbox -->
+          <v-checkbox
+            v-model="work._isSelected"
+            hide-details
+            density="compact"
+            class="search-result-checkbox mt-0 pt-0 mr-2"
+            :disabled="!work._authorshipConfirmed"
+          />
+
+          <div class="flex-grow-1">
+            <div class="search-result-title text-body-2 font-weight-medium">
+              {{ work.display_name || 'Untitled' }}
+            </div>
+            <div class="search-result-meta text-caption text-medium-emphasis">
+              <span v-if="work.publication_year">{{ work.publication_year }}</span>
+              <span v-if="work.primary_location?.source?.display_name">
+                · <span class="font-italic">{{ work.primary_location.source.display_name }}</span>
+              </span>
+            </div>
+
+            <!-- Filtered authorship name bubbles -->
+            <div class="authorship-section mt-2">
+              <template v-if="work._candidateAuthorships && work._candidateAuthorships.length > 0">
+                <div class="text-caption text-medium-emphasis mb-1">Select your name on this work:</div>
+                <div class="d-flex flex-wrap ga-1">
+                  <v-chip
+                    v-for="(candidate, cidx) in work._candidateAuthorships"
+                    :key="cidx"
+                    size="small"
+                    :variant="work._selectedAuthorshipIdx === candidate.idx ? 'flat' : 'outlined'"
+                    :color="work._selectedAuthorshipIdx === candidate.idx ? 'success' : undefined"
+                    @click="selectAuthorship(work, candidate.idx)"
+                  >
+                    {{ candidate.authorship.raw_author_name || candidate.authorship.author?.display_name || 'Unknown' }}
+                  </v-chip>
+                </div>
+                <div class="text-caption text-medium-emphasis mt-1">
+                  Not listed?
+                  <a href="#" @click.prevent="showAllAuthors(work)" class="text-primary">Show all authors</a>
+                  ·
+                  <a href="mailto:support@openalex.org">Contact support</a>
+                </div>
+              </template>
+
+              <template v-else-if="work._showAllAuthors">
+                <div class="text-caption text-medium-emphasis mb-1">Select your name:</div>
+                <div class="d-flex flex-wrap ga-1">
+                  <v-chip
+                    v-for="(authorship, aidx) in work.authorships"
+                    :key="aidx"
+                    size="small"
+                    :variant="work._selectedAuthorshipIdx === aidx ? 'flat' : 'outlined'"
+                    :color="work._selectedAuthorshipIdx === aidx ? 'success' : undefined"
+                    @click="selectAuthorship(work, aidx)"
+                  >
+                    {{ authorship.raw_author_name || authorship.author?.display_name || 'Unknown' }}
+                  </v-chip>
+                </div>
+                <div class="text-caption text-medium-emphasis mt-1">
+                  Not here? <a href="mailto:support@openalex.org">Contact support</a>
+                </div>
+              </template>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Sticky footer with "Add works" button -->
+    <div v-if="selectedWorksCount > 0" class="search-footer">
+      <v-divider />
+      <div class="search-footer-content">
+        <span class="text-body-2">
+          {{ selectedWorksCount }} work{{ selectedWorksCount === 1 ? '' : 's' }} selected
+        </span>
+        <v-btn
+          color="primary"
+          variant="flat"
+          rounded
+          size="small"
+          @click="submitSelectedWorks"
+        >
+          Add works
+        </v-btn>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue';
+import axios from 'axios';
+import { urlBase } from '@/apiConfig';
+
+defineOptions({ name: 'AddWorksSearch' });
+
+const props = defineProps({
+  authorName: {
+    type: String,
+    default: '',
+  },
+  authorId: {
+    type: String,
+    default: '',
+  },
+});
+
+const emit = defineEmits(['add-work']);
+
+const searchQuery = ref('');
+const results = ref([]);
+const totalResults = ref(0);
+const isSearching = ref(false);
+const hasSearched = ref(false);
+const alreadyOnProfile = ref(false);
+
+// Track what name the user searched (for name-based filtering)
+const searchedName = ref('');
+
+const selectedWorksCount = computed(() =>
+  results.value.filter(w => w._isSelected).length
+);
+
+function looksLikePersonName(query) {
+  const words = query.trim().split(/\s+/);
+  if (words.length < 2 || words.length > 4) return false;
+  if (/\d/.test(query)) return false;
+  if (/[;:?!]/.test(query)) return false;
+  const avgLen = words.reduce((sum, w) => sum + w.replace(/\./g, '').length, 0) / words.length;
+  if (avgLen > 10) return false;
+  return true;
+}
+
+function detectSearchType(query) {
+  const trimmed = query.trim();
+
+  // DOI pattern
+  if (trimmed.startsWith('10.') || trimmed.includes('doi.org/')) {
+    const doi = trimmed.replace(/^https?:\/\/(dx\.)?doi\.org\//, '');
+    return { type: 'doi', value: doi };
+  }
+
+  // OpenAlex work ID
+  if (/^[Ww]\d+$/.test(trimmed) || (trimmed.includes('openalex.org/') && /[Ww]\d+/.test(trimmed))) {
+    const match = trimmed.match(/([Ww]\d+)/);
+    if (match) return { type: 'openalex_id', value: match[1] };
+  }
+
+  // Detect person name vs title
+  if (looksLikePersonName(trimmed)) {
+    return { type: 'author_name', value: trimmed };
+  }
+
+  // Default: title search
+  return { type: 'title', value: trimmed };
+}
+
+function normalizeName(name) {
+  if (!name) return '';
+  let n = name.trim();
+  if (n.includes(',')) {
+    const parts = n.split(',').map(p => p.trim());
+    n = parts.reverse().join(' ');
+  }
+  return n.toLowerCase().replace(/[^a-z ]/g, '').replace(/\s+/g, ' ').trim();
+}
+
+function nameSimilarity(name1, name2) {
+  if (!name1 || !name2) return 0;
+  const a = normalizeName(name1);
+  const b = normalizeName(name2);
+  if (a === b) return 1;
+
+  const aWords = a.split(' ');
+  const bWords = b.split(' ');
+  const aLast = aWords[aWords.length - 1];
+  const bLast = bWords[bWords.length - 1];
+  if (aLast !== bLast) {
+    if (a.includes(b) || b.includes(a)) return 0.5;
+    return 0;
+  }
+
+  const aFirst = aWords[0] || '';
+  const bFirst = bWords[0] || '';
+  if (aFirst === bFirst) return 1;
+  if (aFirst.startsWith(bFirst) || bFirst.startsWith(aFirst)) return 0.9;
+  if (aFirst[0] === bFirst[0]) return 0.7;
+  return 0.6;
+}
+
+/**
+ * Find candidate authorships that reasonably match the user's name or search query.
+ * Returns only those with similarity >= 0.6, sorted by score descending.
+ */
+function findCandidateAuthorships(work, matchName) {
+  if (!work.authorships || work.authorships.length === 0) return [];
+
+  const candidates = [];
+  work.authorships.forEach((authorship, idx) => {
+    const rawName = authorship.raw_author_name || '';
+    const displayName = authorship.author?.display_name || '';
+    const score = Math.max(
+      nameSimilarity(matchName, rawName),
+      nameSimilarity(matchName, displayName)
+    );
+    if (score >= 0.6) {
+      candidates.push({ idx, authorship, score });
+    }
+  });
+
+  return candidates.sort((a, b) => b.score - a.score);
+}
+
+async function doSearch() {
+  const query = searchQuery.value?.trim();
+  if (!query) return;
+
+  isSearching.value = true;
+  hasSearched.value = true;
+  alreadyOnProfile.value = false;
+  results.value = [];
+
+  try {
+    const detected = detectSearchType(query);
+    let url;
+
+    // Track the name to use for authorship matching
+    if (detected.type === 'author_name') {
+      searchedName.value = detected.value;
+    } else {
+      searchedName.value = props.authorName;
+    }
+
+    if (detected.type === 'doi') {
+      url = `${urlBase.api}/works/doi:${detected.value}`;
+      try {
+        const resp = await axios.get(url);
+        results.value = [resp.data];
+        totalResults.value = 1;
+      } catch {
+        results.value = [];
+        totalResults.value = 0;
+      }
+    } else if (detected.type === 'openalex_id') {
+      url = `${urlBase.api}/works/${detected.value.toUpperCase()}`;
+      try {
+        const resp = await axios.get(url);
+        results.value = [resp.data];
+        totalResults.value = 1;
+      } catch {
+        results.value = [];
+        totalResults.value = 0;
+      }
+    } else if (detected.type === 'author_name') {
+      const authorShortId = props.authorId.replace('https://openalex.org/', '');
+      url = `${urlBase.api}/works?filter=raw_author_name.search:${encodeURIComponent(detected.value)},authorships.author.id:!${authorShortId}&per_page=10`;
+      const resp = await axios.get(url);
+      results.value = resp.data.results || [];
+      totalResults.value = resp.data.meta?.count || results.value.length;
+    } else {
+      const authorShortId = props.authorId.replace('https://openalex.org/', '');
+      url = `${urlBase.api}/works?filter=title.search:${encodeURIComponent(detected.value)},authorships.author.id:!${authorShortId}&per_page=10`;
+      const resp = await axios.get(url);
+      results.value = resp.data.results || [];
+      totalResults.value = resp.data.meta?.count || results.value.length;
+    }
+
+    // Filter out works already on profile for DOI/ID lookups
+    if (detected.type === 'doi' || detected.type === 'openalex_id') {
+      const authorShortId = props.authorId.replace('https://openalex.org/', '').toUpperCase();
+      results.value = results.value.filter(work => {
+        const isAlreadyLinked = work.authorships?.some(a => {
+          const aid = (a.author?.id || '').replace('https://openalex.org/', '').toUpperCase();
+          return aid === authorShortId;
+        });
+        return !isAlreadyLinked;
+      });
+      if (results.value.length === 0 && totalResults.value > 0) {
+        totalResults.value = 0;
+        alreadyOnProfile.value = true;
+      }
+    }
+
+    // Find candidate authorships for each result
+    const matchName = searchedName.value || props.authorName;
+    results.value.forEach(work => {
+      const candidates = findCandidateAuthorships(work, matchName);
+      work._candidateAuthorships = candidates;
+      work._showAllAuthors = candidates.length === 0;
+      work._isSelected = false;
+      work._authorshipConfirmed = false;
+
+      // If exactly one strong match, auto-select it
+      if (candidates.length === 1 && candidates[0].score >= 0.7) {
+        work._selectedAuthorshipIdx = candidates[0].idx;
+        work._authorshipConfirmed = true;
+        work._isSelected = true; // auto-check
+      } else if (candidates.length > 0) {
+        work._selectedAuthorshipIdx = null;
+        work._authorshipConfirmed = false;
+      } else {
+        work._selectedAuthorshipIdx = null;
+        work._authorshipConfirmed = false;
+      }
+    });
+  } catch (err) {
+    console.error('Work search error:', err);
+    results.value = [];
+    totalResults.value = 0;
+  } finally {
+    isSearching.value = false;
+  }
+}
+
+function showAllAuthors(work) {
+  work._showAllAuthors = true;
+  work._candidateAuthorships = [];
+}
+
+function selectAuthorship(work, idx) {
+  work._selectedAuthorshipIdx = idx;
+  work._authorshipConfirmed = true;
+  // Auto-check the work when authorship is selected
+  work._isSelected = true;
+}
+
+function submitSelectedWorks() {
+  const selected = results.value.filter(w => w._isSelected && w._authorshipConfirmed);
+  selected.forEach(work => {
+    const authorship = work.authorships[work._selectedAuthorshipIdx];
+    emit('add-work', {
+      workId: work.id,
+      authorshipIdx: work._selectedAuthorshipIdx,
+      authorship,
+    });
+    work._matchState = 'added';
+  });
+}
+
+function clearResults() {
+  results.value = [];
+  totalResults.value = 0;
+  hasSearched.value = false;
+  alreadyOnProfile.value = false;
+  searchedName.value = '';
+}
+</script>
+
+<style scoped>
+.search-result-item {
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.search-result-item:last-child {
+  border-bottom: none;
+}
+
+.search-result-item--selected {
+  background: rgba(76, 175, 80, 0.04);
+  border-left: 3px solid #4CAF50;
+  padding-left: 12px;
+}
+
+.search-result-title {
+  color: rgba(0, 0, 0, 0.87);
+  line-height: 1.4;
+}
+
+.search-result-checkbox {
+  flex-shrink: 0;
+}
+
+.authorship-section {
+  padding: 4px 0;
+}
+
+.search-footer {
+  position: sticky;
+  bottom: 0;
+  background: white;
+  z-index: 1;
+  margin: 0 -16px;
+  padding: 0 16px;
+}
+
+.search-footer-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 0;
+}
+</style>

--- a/src/components/AuthorCuration/AuthorDisplayNameEditor.vue
+++ b/src/components/AuthorCuration/AuthorDisplayNameEditor.vue
@@ -1,0 +1,131 @@
+<template>
+  <div v-if="isOwner" class="display-name-editor">
+    <v-menu v-model="menuOpen" :close-on-content-click="false" location="bottom start">
+      <template #activator="{ props: menuProps }">
+        <v-btn
+          v-bind="menuProps"
+          variant="text"
+          size="x-small"
+          class="ml-2 edit-btn"
+          icon
+        >
+          <v-icon size="16">mdi-pencil-outline</v-icon>
+        </v-btn>
+      </template>
+
+      <v-card min-width="300" max-width="400" rounded>
+        <v-card-title class="text-body-1 font-weight-bold">
+          Change display name
+        </v-card-title>
+        <v-card-text class="pt-0">
+          <div class="text-caption text-medium-emphasis mb-3">
+            Select from your known name variants:
+          </div>
+          <v-radio-group
+            v-model="selectedName"
+            hide-details
+            density="compact"
+          >
+            <v-radio
+              v-for="name in allNames"
+              :key="name"
+              :label="name"
+              :value="name"
+              density="compact"
+            />
+          </v-radio-group>
+
+          <div class="text-caption text-medium-emphasis mt-3">
+            Don't see the right name?
+            <a href="mailto:support@openalex.org">Contact support</a>
+          </div>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" size="small" rounded @click="menuOpen = false">
+            Cancel
+          </v-btn>
+          <v-btn
+            color="primary"
+            variant="flat"
+            size="small"
+            rounded
+            :disabled="selectedName === currentDisplayName"
+            :loading="isSaving"
+            @click="saveDisplayName"
+          >
+            Save
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-menu>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue';
+
+defineOptions({ name: 'AuthorDisplayNameEditor' });
+
+const props = defineProps({
+  currentDisplayName: {
+    type: String,
+    default: '',
+  },
+  alternateNames: {
+    type: Array,
+    default: () => [],
+  },
+  isOwner: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['update-name']);
+
+const menuOpen = ref(false);
+const isSaving = ref(false);
+const selectedName = ref(props.currentDisplayName);
+
+// Combine current name + alternates, deduplicated
+const allNames = computed(() => {
+  const names = new Set();
+  if (props.currentDisplayName) names.add(props.currentDisplayName);
+  if (props.alternateNames) {
+    props.alternateNames.forEach(n => names.add(n));
+  }
+  return Array.from(names);
+});
+
+watch(() => props.currentDisplayName, (newVal) => {
+  selectedName.value = newVal;
+});
+
+async function saveDisplayName() {
+  if (selectedName.value === props.currentDisplayName) return;
+  isSaving.value = true;
+  try {
+    emit('update-name', selectedName.value);
+    menuOpen.value = false;
+  } finally {
+    isSaving.value = false;
+  }
+}
+</script>
+
+<style scoped>
+.display-name-editor {
+  display: inline-flex;
+  align-items: center;
+}
+
+.edit-btn {
+  opacity: 0.4;
+  transition: opacity 0.15s;
+}
+
+.edit-btn:hover {
+  opacity: 1;
+}
+</style>

--- a/src/components/AuthorCuration/AuthorFullNameEditor.vue
+++ b/src/components/AuthorCuration/AuthorFullNameEditor.vue
@@ -1,0 +1,155 @@
+<template>
+  <div v-if="isOwner" class="full-name-editor mt-1">
+    <div class="d-flex align-center">
+      <span class="text-body-2 text-medium-emphasis mr-1">Full name:</span>
+      <span class="text-body-2 font-weight-medium">{{ currentFullName || 'Not set' }}</span>
+
+      <v-tooltip location="top" max-width="280">
+        <template #activator="{ props: tooltipProps }">
+          <v-icon
+            v-bind="tooltipProps"
+            size="14"
+            class="ml-1"
+            color="grey"
+          >
+            mdi-information-outline
+          </v-icon>
+        </template>
+        Your full name is used for matching purposes when adding works to your profile.
+        Select the longest accurate name you currently use.
+      </v-tooltip>
+
+      <v-menu v-model="menuOpen" :close-on-content-click="false" location="bottom start">
+        <template #activator="{ props: menuProps }">
+          <v-btn
+            v-bind="menuProps"
+            variant="text"
+            size="x-small"
+            class="ml-1 edit-btn"
+            icon
+          >
+            <v-icon size="16">mdi-pencil-outline</v-icon>
+          </v-btn>
+        </template>
+
+        <v-card min-width="300" max-width="400" rounded>
+          <v-card-title class="text-body-1 font-weight-bold">
+            Set full name
+          </v-card-title>
+          <v-card-text class="pt-0">
+            <div class="text-caption text-medium-emphasis mb-3">
+              Select the longest accurate name you currently use:
+            </div>
+            <v-radio-group
+              v-model="selectedName"
+              hide-details
+              density="compact"
+            >
+              <v-radio
+                v-for="name in allNames"
+                :key="name"
+                :label="name"
+                :value="name"
+                density="compact"
+              />
+            </v-radio-group>
+
+            <div class="text-caption text-medium-emphasis mt-3">
+              Don't see the right name?
+              <a href="mailto:support@openalex.org">Contact support</a>
+            </div>
+          </v-card-text>
+          <v-card-actions>
+            <v-spacer />
+            <v-btn variant="text" size="small" rounded @click="menuOpen = false">
+              Cancel
+            </v-btn>
+            <v-btn
+              color="primary"
+              variant="flat"
+              size="small"
+              rounded
+              :disabled="selectedName === currentFullName"
+              :loading="isSaving"
+              @click="saveFullName"
+            >
+              Save
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-menu>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue';
+
+defineOptions({ name: 'AuthorFullNameEditor' });
+
+const props = defineProps({
+  currentFullName: {
+    type: String,
+    default: '',
+  },
+  currentDisplayName: {
+    type: String,
+    default: '',
+  },
+  alternateNames: {
+    type: Array,
+    default: () => [],
+  },
+  isOwner: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['update-full-name']);
+
+const menuOpen = ref(false);
+const isSaving = ref(false);
+const selectedName = ref(props.currentFullName || '');
+
+// Combine current display name + alternates, deduplicated
+const allNames = computed(() => {
+  const names = new Set();
+  if (props.currentDisplayName) names.add(props.currentDisplayName);
+  if (props.alternateNames) {
+    props.alternateNames.forEach(n => names.add(n));
+  }
+  // Sort by length descending so the longest names are first
+  return Array.from(names).sort((a, b) => b.length - a.length);
+});
+
+watch(() => props.currentFullName, (newVal) => {
+  selectedName.value = newVal || '';
+});
+
+async function saveFullName() {
+  if (selectedName.value === props.currentFullName) return;
+  isSaving.value = true;
+  try {
+    emit('update-full-name', selectedName.value);
+    menuOpen.value = false;
+  } finally {
+    isSaving.value = false;
+  }
+}
+</script>
+
+<style scoped>
+.full-name-editor {
+  padding-left: 4px;
+}
+
+.edit-btn {
+  opacity: 0.4;
+  transition: opacity 0.15s;
+}
+
+.edit-btn:hover {
+  opacity: 1;
+}
+</style>

--- a/src/components/AuthorCuration/AuthorWorksList.vue
+++ b/src/components/AuthorCuration/AuthorWorksList.vue
@@ -1,0 +1,316 @@
+<template>
+  <v-card variant="outlined" class="rounded-o bg-white">
+    <v-toolbar flat color="white" class="entity-page-section-title">
+      <template #prepend>
+        <v-icon variant="text" color="grey-darken-2" start>mdi-file-document-outline</v-icon>
+      </template>
+      <v-toolbar-title class="font-weight-bold">
+        Works
+        <span v-if="totalCount" class="text-body-2 text-medium-emphasis ml-1">
+          ({{ totalCount.toLocaleString() }})
+        </span>
+      </v-toolbar-title>
+      <v-spacer />
+
+      <!-- Remove selected works button (owner only) -->
+      <v-btn
+        v-if="isOwner && selectedForRemoval.size > 0"
+        color="error"
+        variant="text"
+        rounded
+        size="small"
+        @click="isRemoveDialogOpen = true"
+      >
+        Remove {{ selectedForRemoval.size }} work{{ selectedForRemoval.size > 1 ? 's' : '' }}
+      </v-btn>
+
+      <!-- Add works button (owner only) -->
+      <v-btn
+        v-if="isOwner"
+        variant="text"
+        rounded
+        size="small"
+        color="primary"
+        @click="$emit('add-works')"
+      >
+        <v-icon start size="16">mdi-plus</v-icon>
+        Add
+      </v-btn>
+    </v-toolbar>
+
+    <v-divider />
+
+    <!-- Loading state -->
+    <div v-if="isLoading && works.length === 0" class="pa-6 text-center">
+      <v-progress-circular indeterminate size="24" width="2" />
+    </div>
+
+    <!-- Works list -->
+    <v-list v-else class="py-0">
+      <div
+        v-for="work in works"
+        :key="work.id"
+        class="work-item"
+      >
+        <div class="work-item-content">
+          <!-- Subtle checkbox for removal (owner only) -->
+          <v-checkbox
+            v-if="isOwner"
+            :model-value="selectedForRemoval.has(work.id)"
+            density="compact"
+            hide-details
+            class="work-checkbox"
+            @update:model-value="toggleRemoval(work.id)"
+          />
+
+          <div class="work-item-text">
+            <!-- Title -->
+            <router-link
+              :to="workLink(work)"
+              class="work-title text-body-2 font-weight-medium text-decoration-none"
+              v-html="work.display_name || 'Untitled'"
+            />
+
+            <!-- Authors and metadata -->
+            <div class="work-meta">
+              <span v-if="work.publication_year">{{ work.publication_year }}</span>
+              <template v-if="work.authorships?.length">
+                <span> · </span>
+                <span class="work-authors">
+                  {{ formatAuthors(work.authorships) }}
+                </span>
+              </template>
+              <template v-if="work.primary_location?.source?.display_name">
+                <span> · </span>
+                <span class="font-italic">{{ work.primary_location.source.display_name }}</span>
+              </template>
+            </div>
+
+            <!-- Cited by count -->
+            <div v-if="work.cited_by_count" class="work-citations">
+              <v-icon size="12" class="mr-1" style="opacity: 0.4">mdi-format-quote-close</v-icon>
+              Cited by {{ work.cited_by_count.toLocaleString() }}
+            </div>
+
+            <!-- Pending removal notice -->
+            <div v-if="pendingRemovals.has(work.id)" class="work-pending">
+              <v-icon size="12" class="mr-1">mdi-clock-outline</v-icon>
+              Removal pending
+            </div>
+          </div>
+        </div>
+      </div>
+    </v-list>
+
+    <!-- Load more -->
+    <div v-if="hasMore" class="pa-4 text-center">
+      <v-btn
+        variant="text"
+        rounded
+        size="small"
+        color="primary"
+        :loading="isLoading"
+        @click="loadMore"
+      >
+        Show more works
+      </v-btn>
+    </div>
+
+    <!-- Removal confirmation dialog -->
+    <v-dialog v-model="isRemoveDialogOpen" max-width="480">
+      <v-card rounded>
+        <v-card-title>Remove works from your profile?</v-card-title>
+        <v-card-text>
+          <p>
+            You are about to remove {{ selectedForRemoval.size }}
+            work{{ selectedForRemoval.size > 1 ? 's' : '' }} from your author profile.
+            This will submit a curation request and may take a few days to take effect.
+          </p>
+          <p class="text-medium-emphasis mt-2">
+            This will not delete the work from OpenAlex — it only removes the link between
+            the work and your author profile.
+          </p>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" rounded @click="isRemoveDialogOpen = false">
+            Cancel
+          </v-btn>
+          <v-btn color="error" variant="flat" rounded @click="confirmRemovals">
+            Yes, remove
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-card>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue';
+import axios from 'axios';
+import { urlBase } from '@/apiConfig';
+import filters from '@/filters';
+
+defineOptions({ name: 'AuthorWorksList' });
+
+const props = defineProps({
+  authorId: {
+    type: String,
+    required: true,
+  },
+  isOwner: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['add-works', 'remove-works']);
+
+const works = ref([]);
+const totalCount = ref(0);
+const isLoading = ref(false);
+const currentPage = ref(1);
+const perPage = 25;
+const selectedForRemoval = ref(new Set());
+const pendingRemovals = ref(new Set());
+const isRemoveDialogOpen = ref(false);
+
+const hasMore = computed(() => {
+  return works.value.length < totalCount.value;
+});
+
+function workLink(work) {
+  const shortId = work.id?.replace('https://openalex.org/', '');
+  return shortId ? `/${shortId}` : '#';
+}
+
+function formatAuthors(authorships) {
+  if (!authorships || authorships.length === 0) return '';
+  const names = authorships.map(a => a.author?.display_name || a.raw_author_name || 'Unknown');
+  if (names.length <= 3) return names.join(', ');
+  return names.slice(0, 3).join(', ') + ` +${names.length - 3} more`;
+}
+
+function toggleRemoval(workId) {
+  const newSet = new Set(selectedForRemoval.value);
+  if (newSet.has(workId)) {
+    newSet.delete(workId);
+  } else {
+    newSet.add(workId);
+  }
+  selectedForRemoval.value = newSet;
+}
+
+function confirmRemovals() {
+  const workIds = Array.from(selectedForRemoval.value);
+  // Mark as pending
+  workIds.forEach(id => pendingRemovals.value.add(id));
+  selectedForRemoval.value = new Set();
+  isRemoveDialogOpen.value = false;
+  emit('remove-works', workIds);
+}
+
+async function fetchWorks(page = 1) {
+  isLoading.value = true;
+  try {
+    const shortId = props.authorId.replace('https://openalex.org/', '');
+    const apiUrl = `${urlBase.api}/works?filter=authorships.author.id:${shortId}&sort=publication_year:desc&per_page=${perPage}&page=${page}`;
+    const resp = await axios.get(apiUrl);
+    if (page === 1) {
+      works.value = resp.data.results || [];
+    } else {
+      works.value = [...works.value, ...(resp.data.results || [])];
+    }
+    totalCount.value = resp.data.meta?.count || 0;
+    currentPage.value = page;
+  } catch (err) {
+    console.error('Failed to fetch author works:', err);
+  } finally {
+    isLoading.value = false;
+  }
+}
+
+function loadMore() {
+  fetchWorks(currentPage.value + 1);
+}
+
+onMounted(() => {
+  fetchWorks(1);
+});
+
+watch(() => props.authorId, () => {
+  works.value = [];
+  currentPage.value = 1;
+  fetchWorks(1);
+});
+</script>
+
+<style scoped>
+.work-item {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.work-item:last-child {
+  border-bottom: none;
+}
+
+.work-item-content {
+  display: flex;
+  align-items: flex-start;
+  padding: 12px 16px;
+  gap: 4px;
+}
+
+.work-checkbox {
+  flex-shrink: 0;
+  margin-top: -2px;
+  opacity: 0.4;
+  transition: opacity 0.15s;
+}
+
+.work-item:hover .work-checkbox {
+  opacity: 1;
+}
+
+.work-item-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.work-title {
+  display: block;
+  line-height: 1.4;
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.work-title:hover {
+  text-decoration: underline !important;
+}
+
+.work-meta {
+  font-size: 13px;
+  line-height: 1.4;
+  color: rgba(0, 0, 0, 0.6);
+  margin-top: 2px;
+}
+
+.work-authors {
+  /* keep inline */
+}
+
+.work-citations {
+  display: flex;
+  align-items: center;
+  font-size: 12px;
+  color: rgba(0, 0, 0, 0.45);
+  margin-top: 2px;
+}
+
+.work-pending {
+  display: flex;
+  align-items: center;
+  font-size: 12px;
+  color: #E65100;
+  margin-top: 4px;
+}
+</style>

--- a/src/components/AuthorProfile/AuthorProfileClaimed.vue
+++ b/src/components/AuthorProfile/AuthorProfileClaimed.vue
@@ -1,0 +1,93 @@
+<template>
+  <div class="author-claimed">
+    <div class="author-claimed-header">
+      <v-icon color="primary" size="18" class="mr-2">mdi-check-decagram</v-icon>
+      <a
+        :href="profileUrl"
+        target="_blank"
+        class="author-claimed-name"
+      >
+        {{ authorData?.display_name || 'Loading...' }}
+        <v-icon size="14" class="ml-1">mdi-open-in-new</v-icon>
+      </a>
+    </div>
+
+    <div class="author-claimed-help">
+      Need to change your claimed profile? Contact
+      <a href="mailto:support@openalex.org">support@openalex.org</a>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue';
+import axios from 'axios';
+import { urlBase } from '@/apiConfig';
+
+defineOptions({ name: 'AuthorProfileClaimed' });
+
+const props = defineProps({
+  authorId: {
+    type: String,
+    required: true,
+  },
+});
+
+const authorData = ref(null);
+
+const shortId = computed(() => {
+  if (!props.authorId) return '';
+  // Extract just the ID part (e.g., A5086928770) from full URL or short form
+  const match = props.authorId.match(/[Aa]\d+/);
+  return match ? match[0].toUpperCase() : props.authorId;
+});
+
+const profileUrl = computed(() => {
+  return `https://openalex.org/authors/${shortId.value}`;
+});
+
+onMounted(async () => {
+  try {
+    const resp = await axios.get(`${urlBase.api}/authors/${shortId.value}`);
+    authorData.value = resp.data;
+  } catch (err) {
+    console.error('Failed to fetch claimed author profile:', err);
+  }
+});
+</script>
+
+<style scoped>
+.author-claimed-header {
+  display: flex;
+  align-items: center;
+}
+
+.author-claimed-name {
+  display: inline-flex;
+  align-items: center;
+  font-size: 14px;
+  font-weight: 600;
+  color: rgb(var(--v-theme-primary));
+  text-decoration: none;
+}
+
+.author-claimed-name:hover {
+  text-decoration: underline;
+}
+
+.author-claimed-help {
+  font-size: 12px;
+  color: #9CA3AF;
+  margin-top: 6px;
+  padding-left: 26px;
+}
+
+.author-claimed-help a {
+  color: rgb(var(--v-theme-primary));
+  text-decoration: none;
+}
+
+.author-claimed-help a:hover {
+  text-decoration: underline;
+}
+</style>

--- a/src/components/AuthorProfile/AuthorProfileSearch.vue
+++ b/src/components/AuthorProfile/AuthorProfileSearch.vue
@@ -1,0 +1,237 @@
+<template>
+  <div class="author-search">
+    <!-- Search input -->
+    <div class="author-search-input-wrap">
+      <v-text-field
+        v-model="searchQuery"
+        placeholder="Search by name, OpenAlex ID (e.g. A5086928770), or ORCID"
+        variant="outlined"
+        density="compact"
+        hide-details
+        prepend-inner-icon="mdi-magnify"
+        :loading="isSearching"
+        @keydown.enter="doSearch"
+        clearable
+        @click:clear="clearResults"
+      />
+    </div>
+
+    <!-- Guidance text -->
+    <div v-if="!results.length && !isSearching && !hasSearched" class="author-search-hint">
+      Search for your author profile to claim it. If you have multiple profiles in OpenAlex,
+      select the one that best represents your body of work. You can add missing publications
+      to your profile after claiming it.
+    </div>
+
+    <!-- Loading state -->
+    <div v-if="isSearching" class="author-search-loading">
+      <v-progress-circular indeterminate size="24" width="2" class="mr-3" />
+      Searching author profiles...
+    </div>
+
+    <!-- No results -->
+    <div v-if="hasSearched && !isSearching && results.length === 0" class="author-search-empty">
+      <v-icon size="20" class="mr-2">mdi-account-search-outline</v-icon>
+      No author profiles found. Try a different name or ID.
+    </div>
+
+    <!-- Results list -->
+    <div v-if="results.length > 0" class="author-search-results">
+      <div class="author-search-results-count">
+        {{ totalResults.toLocaleString() }} result{{ totalResults === 1 ? '' : 's' }} found
+      </div>
+      <AuthorProfileSearchResult
+        v-for="author in results"
+        :key="author.id"
+        :author="author"
+        :selected="selectedAuthorId === author.id"
+        class="mb-2"
+        @select="selectAuthor(author)"
+      />
+    </div>
+
+    <!-- Claim button -->
+    <div v-if="selectedAuthorId" class="author-search-actions">
+      <v-btn
+        color="primary"
+        variant="flat"
+        rounded
+        :loading="isClaiming"
+        @click="claimProfile"
+      >
+        Claim this profile
+      </v-btn>
+      <v-btn
+        variant="text"
+        rounded
+        @click="selectedAuthorId = null"
+      >
+        Cancel
+      </v-btn>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import axios from 'axios';
+import { urlBase } from '@/apiConfig';
+import AuthorProfileSearchResult from './AuthorProfileSearchResult.vue';
+
+defineOptions({ name: 'AuthorProfileSearch' });
+
+const emit = defineEmits(['claimed']);
+
+const searchQuery = ref('');
+const results = ref([]);
+const totalResults = ref(0);
+const isSearching = ref(false);
+const hasSearched = ref(false);
+const selectedAuthorId = ref(null);
+const isClaiming = ref(false);
+
+function detectSearchType(query) {
+  const trimmed = query.trim();
+
+  // OpenAlex ID: starts with A (case-insensitive) followed by digits
+  if (/^[Aa]\d+$/.test(trimmed)) {
+    return { type: 'openalex_id', value: trimmed };
+  }
+
+  // Full OpenAlex URL
+  if (trimmed.includes('openalex.org/') && /[Aa]\d+/.test(trimmed)) {
+    const match = trimmed.match(/([Aa]\d+)/);
+    if (match) return { type: 'openalex_id', value: match[1] };
+  }
+
+  // ORCID: 0000-0000-0000-0000 pattern or full URL
+  const orcidPattern = /(\d{4}-\d{4}-\d{4}-\d{3}[\dX])/i;
+  const orcidMatch = trimmed.match(orcidPattern);
+  if (orcidMatch) {
+    return { type: 'orcid', value: orcidMatch[1] };
+  }
+
+  // Default: name search
+  return { type: 'name', value: trimmed };
+}
+
+async function doSearch() {
+  const query = searchQuery.value?.trim();
+  if (!query) return;
+
+  isSearching.value = true;
+  hasSearched.value = true;
+  results.value = [];
+  selectedAuthorId.value = null;
+
+  try {
+    const detected = detectSearchType(query);
+    let url;
+
+    if (detected.type === 'openalex_id') {
+      // Fetch single author by ID
+      const id = detected.value.toUpperCase();
+      url = `${urlBase.api}/authors/${id}`;
+      try {
+        const resp = await axios.get(url);
+        results.value = [resp.data];
+        totalResults.value = 1;
+      } catch (e) {
+        results.value = [];
+        totalResults.value = 0;
+      }
+    } else if (detected.type === 'orcid') {
+      // Search by ORCID filter
+      url = `${urlBase.api}/authors?filter=orcid:${detected.value}&per_page=10`;
+      const resp = await axios.get(url);
+      results.value = resp.data.results || [];
+      totalResults.value = resp.data.meta?.count || results.value.length;
+    } else {
+      // Name search, sort by works count descending
+      url = `${urlBase.api}/authors?search=${encodeURIComponent(detected.value)}&sort=works_count:desc&per_page=10`;
+      const resp = await axios.get(url);
+      results.value = resp.data.results || [];
+      totalResults.value = resp.data.meta?.count || results.value.length;
+    }
+  } catch (err) {
+    console.error('Author search error:', err);
+    results.value = [];
+    totalResults.value = 0;
+  } finally {
+    isSearching.value = false;
+  }
+}
+
+function selectAuthor(author) {
+  selectedAuthorId.value = selectedAuthorId.value === author.id ? null : author.id;
+}
+
+async function claimProfile() {
+  if (!selectedAuthorId.value) return;
+  isClaiming.value = true;
+  try {
+    emit('claimed', selectedAuthorId.value);
+  } finally {
+    isClaiming.value = false;
+  }
+}
+
+function clearResults() {
+  results.value = [];
+  totalResults.value = 0;
+  hasSearched.value = false;
+  selectedAuthorId.value = null;
+}
+</script>
+
+<style scoped>
+.author-search {
+  padding: 0;
+}
+
+.author-search-input-wrap {
+  margin-bottom: 12px;
+}
+
+.author-search-hint {
+  font-size: 13px;
+  color: #6B6B6B;
+  line-height: 1.5;
+  padding: 8px 0;
+}
+
+.author-search-loading {
+  display: flex;
+  align-items: center;
+  font-size: 13px;
+  color: #6B6B6B;
+  padding: 16px 0;
+}
+
+.author-search-empty {
+  display: flex;
+  align-items: center;
+  font-size: 13px;
+  color: #6B6B6B;
+  padding: 16px 0;
+}
+
+.author-search-results {
+  margin-top: 4px;
+}
+
+.author-search-results-count {
+  font-size: 12px;
+  color: #9CA3AF;
+  margin-bottom: 8px;
+}
+
+.author-search-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid #F0F0F0;
+}
+</style>

--- a/src/components/AuthorProfile/AuthorProfileSearchResult.vue
+++ b/src/components/AuthorProfile/AuthorProfileSearchResult.vue
@@ -1,0 +1,185 @@
+<template>
+  <div
+    class="author-result"
+    :class="{ 'author-result--selected': selected }"
+    @click="$emit('select')"
+  >
+    <div class="author-result-main">
+      <div class="author-result-name">
+        {{ author.display_name }}
+      </div>
+      <div class="author-result-meta">
+        <span class="author-result-works">
+          <v-icon size="14" class="mr-1">mdi-file-document-outline</v-icon>
+          {{ author.works_count?.toLocaleString() || 0 }} works
+        </span>
+        <span v-if="author.cited_by_count" class="author-result-citations">
+          <v-icon size="14" class="mr-1">mdi-format-quote-close</v-icon>
+          {{ author.cited_by_count?.toLocaleString() }} citations
+        </span>
+      </div>
+
+      <!-- Last known institution -->
+      <div v-if="lastInstitution" class="author-result-detail">
+        <v-icon size="14" class="mr-1">mdi-domain</v-icon>
+        {{ lastInstitution }}
+      </div>
+
+      <!-- All affiliations -->
+      <div v-if="affiliationsList.length > 0" class="author-result-detail">
+        <v-icon size="14" class="mr-1">mdi-map-marker-outline</v-icon>
+        <span class="author-result-affiliations">{{ affiliationsList.join(' · ') }}</span>
+      </div>
+
+      <!-- Top topics -->
+      <div v-if="topTopics.length > 0" class="author-result-topics">
+        <v-chip
+          v-for="topic in topTopics"
+          :key="topic.id"
+          size="x-small"
+          variant="tonal"
+          class="mr-1 mb-1"
+        >
+          {{ topic.display_name }}
+        </v-chip>
+      </div>
+
+      <!-- ORCID if available -->
+      <div v-if="author.orcid" class="author-result-detail author-result-orcid">
+        <v-icon size="14" class="mr-1">mdi-identifier</v-icon>
+        ORCID: {{ formatOrcid(author.orcid) }}
+      </div>
+    </div>
+
+    <div class="author-result-action">
+      <v-icon v-if="selected" color="primary" size="20">mdi-check-circle</v-icon>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+defineOptions({ name: 'AuthorProfileSearchResult' });
+
+const props = defineProps({
+  author: {
+    type: Object,
+    required: true,
+  },
+  selected: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+defineEmits(['select']);
+
+const lastInstitution = computed(() => {
+  const institutions = props.author.last_known_institutions;
+  if (!institutions || institutions.length === 0) return null;
+  return institutions.map(i => i.display_name).join(', ');
+});
+
+const affiliationsList = computed(() => {
+  const affiliations = props.author.affiliations;
+  if (!affiliations || affiliations.length === 0) return [];
+  return affiliations
+    .map(a => a.institution?.display_name)
+    .filter(Boolean)
+    .slice(0, 5);
+});
+
+const topTopics = computed(() => {
+  const topics = props.author.topics;
+  if (!topics || topics.length === 0) return [];
+  return topics.slice(0, 3);
+});
+
+function formatOrcid(orcid) {
+  if (!orcid) return '';
+  return orcid.replace('https://orcid.org/', '');
+}
+</script>
+
+<style scoped>
+.author-result {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border: 1px solid #E5E5E5;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.15s;
+  background: #FFFFFF;
+}
+
+.author-result:hover {
+  border-color: #D0D0D0;
+  background: #FAFAFA;
+}
+
+.author-result--selected {
+  border-color: rgb(var(--v-theme-primary));
+  background: rgba(var(--v-theme-primary), 0.04);
+}
+
+.author-result-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.author-result-name {
+  font-size: 15px;
+  font-weight: 600;
+  color: #1A1A1A;
+  line-height: 1.3;
+}
+
+.author-result-meta {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-top: 4px;
+  font-size: 13px;
+  color: #6B6B6B;
+}
+
+.author-result-works,
+.author-result-citations {
+  display: flex;
+  align-items: center;
+}
+
+.author-result-detail {
+  display: flex;
+  align-items: center;
+  margin-top: 6px;
+  font-size: 13px;
+  color: #6B6B6B;
+}
+
+.author-result-affiliations {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.author-result-topics {
+  margin-top: 8px;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.author-result-orcid {
+  font-size: 12px;
+  color: #9CA3AF;
+}
+
+.author-result-action {
+  flex-shrink: 0;
+  padding-top: 2px;
+  padding-left: 12px;
+}
+</style>

--- a/src/components/AuthorProfile/AuthorProfileSection.vue
+++ b/src/components/AuthorProfile/AuthorProfileSection.vue
@@ -1,0 +1,68 @@
+<template>
+  <SettingsSection v-if="authorCurationEnabled" title="OpenAlex Author Profile">
+    <!-- Already claimed -->
+    <div v-if="userAuthorId" class="pa-4">
+      <AuthorProfileClaimed :author-id="userAuthorId" />
+    </div>
+
+    <!-- Not yet claimed -->
+    <SettingsRow
+      v-else
+      label="Claim your profile"
+      description="Link your OpenAlex author profile to your account"
+    >
+      <v-btn
+        variant="text"
+        class="settings-action"
+        @click="isSearchDialogOpen = true"
+      >
+        Search profiles
+      </v-btn>
+    </SettingsRow>
+
+    <!-- Search dialog -->
+    <v-dialog v-model="isSearchDialogOpen" max-width="640" scrollable>
+      <v-card rounded>
+        <v-card-title class="d-flex align-center justify-space-between">
+          Claim your author profile
+          <v-btn icon variant="text" size="small" @click="isSearchDialogOpen = false">
+            <v-icon>mdi-close</v-icon>
+          </v-btn>
+        </v-card-title>
+        <v-card-text class="pt-0">
+          <AuthorProfileSearch @claimed="handleClaim" />
+        </v-card-text>
+      </v-card>
+    </v-dialog>
+  </SettingsSection>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue';
+import { useStore } from 'vuex';
+import SettingsSection from '@/components/Settings/SettingsSection.vue';
+import SettingsRow from '@/components/Settings/SettingsRow.vue';
+import AuthorProfileClaimed from './AuthorProfileClaimed.vue';
+import AuthorProfileSearch from './AuthorProfileSearch.vue';
+
+defineOptions({ name: 'AuthorProfileSection' });
+
+const store = useStore();
+
+const authorCurationEnabled = computed(() => !!store.getters.featureFlags?.author_curation);
+const userAuthorId = computed(() => store.getters['user/userAuthorId']);
+const isSearchDialogOpen = ref(false);
+
+async function handleClaim(authorId) {
+  try {
+    const shortId = authorId.replace('https://openalex.org/authors/', '')
+                            .replace('https://openalex.org/', '');
+    await store.dispatch('user/setAuthorId', shortId);
+    isSearchDialogOpen.value = false;
+    store.commit('snackbar', 'Author profile claimed!');
+  } catch (err) {
+    console.error('Failed to claim profile:', err);
+    store.commit('snackbar', 'Failed to claim profile. Please try again.');
+  }
+}
+</script>

--- a/src/components/Entity/EntityHeader.vue
+++ b/src/components/Entity/EntityHeader.vue
@@ -1,9 +1,13 @@
 <template>
   <div>
-    <div
-      class="text-h6 text-lg-h5 mb-1"
-      v-html="filters.prettyTitle(displayTitle)"
-    />
+    <div class="d-flex align-center">
+      <div
+        class="text-h6 text-lg-h5 mb-1"
+        v-html="filters.prettyTitle(displayTitle)"
+      />
+      <slot name="after-title" />
+    </div>
+    <slot name="after-header" />
     <div class="d-flex align-center">
       <link-entity-roles-list
         v-if="entityData.roles"

--- a/src/store/user.store.js
+++ b/src/store/user.store.js
@@ -97,6 +97,9 @@ export default {
         setCorrections(state, corrections) {
             state.corrections = corrections;
         },
+        setAuthorIdDirect(state, authorId) {
+            state.authorId = authorId;
+        },
         logout(state) {
             state.id = ""
             state.name = ""

--- a/src/views/Admin/AdminExperimental.vue
+++ b/src/views/Admin/AdminExperimental.vue
@@ -50,6 +50,14 @@ import { urlBase, axiosConfig } from '@/apiConfig';
 
 const store = useStore();
 
+// UI-defined feature flags that may not yet exist in the backend
+const UI_DEFINED_FLAGS = [
+  {
+    name: 'author_curation',
+    description: 'Enable author profile claiming and curation features (display name editing, works add/remove, CV upload).',
+  },
+];
+
 const allFlags = ref([]);
 const loading = ref(true);
 const togglingFlag = ref(null);
@@ -68,9 +76,16 @@ async function fetchFlags() {
       `${urlBase.userApi}/feature-flags`,
       axiosConfig({ userAuth: true })
     );
-    allFlags.value = resp.data.results || [];
+    const backendFlags = resp.data.results || [];
+
+    // Merge: backend flags take precedence, then append UI-defined flags not in backend
+    const backendNames = new Set(backendFlags.map(f => f.name));
+    const uiOnly = UI_DEFINED_FLAGS.filter(f => !backendNames.has(f.name));
+    allFlags.value = [...backendFlags, ...uiOnly];
   } catch (e) {
     console.error('Failed to fetch feature flags:', e);
+    // Fallback: show UI-defined flags even if backend is unreachable
+    allFlags.value = [...UI_DEFINED_FLAGS];
   } finally {
     loading.value = false;
   }
@@ -89,6 +104,13 @@ async function toggleFlag(flagName, enable) {
     await store.dispatch('user/fetchUser');
   } catch (e) {
     console.error('Failed to toggle feature flag:', e);
+    // Client-side fallback: toggle locally when backend doesn't know the flag yet
+    const currentFlags = Object.keys(featureFlags.value).filter(k => featureFlags.value[k]);
+    if (enable) {
+      store.commit('setFeatureFlags', [...currentFlags, flagName]);
+    } else {
+      store.commit('setFeatureFlags', currentFlags.filter(f => f !== flagName));
+    }
   } finally {
     togglingFlag.value = null;
   }

--- a/src/views/EntityPage.vue
+++ b/src/views/EntityPage.vue
@@ -17,7 +17,25 @@
         :entity-data="entityData"
         :entity-type="myEntityType"
         class="mb-4"
-      />
+      >
+        <template v-if="authorCurationEnabled && isAuthorOwner" #after-title>
+          <AuthorDisplayNameEditor
+            :current-display-name="entityData.display_name"
+            :alternate-names="entityData.display_name_alternatives || []"
+            :is-owner="isAuthorOwner"
+            @update-name="handleDisplayNameUpdate"
+          />
+        </template>
+        <template v-if="authorCurationEnabled && isAuthorOwner" #after-header>
+          <AuthorFullNameEditor
+            :current-full-name="entityData.full_name || ''"
+            :current-display-name="entityData.display_name"
+            :alternate-names="entityData.display_name_alternatives || []"
+            :is-owner="isAuthorOwner"
+            @update-full-name="handleFullNameUpdate"
+          />
+        </template>
+      </entity-header>
 
       <v-row v-if="myEntityType === 'works'">
         <v-col>
@@ -90,6 +108,51 @@
         </v-col>
       </v-row>
 
+      <!-- Author entity page with curation features -->
+      <v-row v-else-if="isAuthor && authorCurationEnabled">
+        <v-col cols="12" md="7">
+          <v-card variant="outlined" class="rounded-o py-6 bg-white">
+            <entity-new
+              :data="entityData"
+              :type="myEntityType"
+            />
+          </v-card>
+
+          <div class="mt-3">
+            <AuthorWorksList
+              :author-id="entityData.id"
+              :is-owner="isAuthorOwner"
+              @add-works="isAddWorksDialogOpen = true"
+              @remove-works="handleRemoveWorks"
+            />
+          </div>
+        </v-col>
+
+        <v-col cols="12" md="5">
+          <v-card flat class="rounded-o px-2 pb-3">
+            <v-toolbar flat color="white" class="entity-page-section-title">
+              <template #prepend>
+                <v-icon variant="text" color="grey-darken-2" start>mdi-clipboard-outline</v-icon>
+              </template>
+              <v-toolbar-title class="font-weight-bold">
+                Key stats
+              </v-toolbar-title>
+              <v-spacer/>
+            </v-toolbar>
+            <group-by
+              v-for="groupByKey in authorGroupByKeys"
+              :key="groupByKey"
+              :filter-key="groupByKey"
+              :filter-by="[myWorksFilter]"
+              entity-type="works"
+              :is-entity-page="true"
+              class="mb-3"
+            />
+          </v-card>
+        </v-col>
+      </v-row>
+
+      <!-- Generic entity page (non-author, non-works) -->
       <v-row v-else>
         <v-col v-if="showEntityPageStats" cols="12" md="7">
           <v-card variant="outlined" class="rounded-o py-6 bg-white">
@@ -154,6 +217,15 @@
           </v-card>
         </v-col>
       </v-row>
+
+      <!-- Add Works Dialog (author curation) -->
+      <AddWorksDialog
+        v-if="authorCurationEnabled && isAuthorOwner"
+        v-model="isAddWorksDialogOpen"
+        :author-name="entityData?.display_name || ''"
+        :author-id="entityData?.id || ''"
+        @add-work="handleAddWork"
+      />
     </v-container>
   </div>
 </template>
@@ -174,6 +246,12 @@ import EntityNew from '@/components/Entity/EntityNew.vue';
 import EntityHeader from '@/components/Entity/EntityHeader.vue';
 import SerpResultsListItem from '@/components/SerpResultsListItem.vue';
 import GroupBy from '@/components/GroupBy/GroupBy.vue';
+
+// Author curation components (feature-flagged)
+import AuthorWorksList from '@/components/AuthorCuration/AuthorWorksList.vue';
+import AuthorDisplayNameEditor from '@/components/AuthorCuration/AuthorDisplayNameEditor.vue';
+import AuthorFullNameEditor from '@/components/AuthorCuration/AuthorFullNameEditor.vue';
+import AddWorksDialog from '@/components/AuthorCuration/AddWorksDialog.vue';
 
 defineOptions({ name: 'EntityPage' });
 
@@ -209,6 +287,19 @@ const groupByKeys = computed(() => {
 const isAward = computed(() => myEntityType.value === 'awards');
 
 const showEntityPageStats = computed(() => store.state.showEntityPageStats);
+
+// Author curation computed properties
+const isAuthor = computed(() => myEntityType.value === 'authors');
+const authorCurationEnabled = computed(() => !!store.getters.featureFlags?.author_curation);
+const userAuthorId = computed(() => store.getters['user/userAuthorId']);
+const isAuthorOwner = computed(() => {
+  if (!authorCurationEnabled.value) return false;
+  if (!isAuthor.value || !userAuthorId.value || !entityData.value?.id) return false;
+  const normalize = (id) => (id || '').replace('https://openalex.org/', '').toUpperCase();
+  return normalize(userAuthorId.value) === normalize(entityData.value.id);
+});
+const authorGroupByKeys = computed(() => ['publication_year', 'open_access.is_oa', 'primary_topic.id']);
+const isAddWorksDialogOpen = ref(false);
 
 const allLocations = computed(() => {
   if (!entityData.value || myEntityType.value !== 'works') return [];
@@ -304,6 +395,29 @@ const getWorks = async () => {
 const viewMyWorks = () => {
   console.log(myWorksFilter.value);
   return url.pushNewFilters([myWorksFilter.value], 'works');
+};
+
+// Author curation handlers
+const handleDisplayNameUpdate = (newName) => {
+  // TODO: Submit to corrections API once endpoint exists
+  console.log('Display name update requested:', newName);
+  store.commit('snackbar', `Display name update to "${newName}" submitted.`);
+};
+
+const handleFullNameUpdate = (newFullName) => {
+  // TODO: Submit to corrections API once endpoint exists
+  console.log('Full name update requested:', newFullName);
+  store.commit('snackbar', `Full name update to "${newFullName}" submitted.`);
+};
+
+const handleAddWork = (workData) => {
+  console.log('Add work requested:', workData);
+  store.commit('snackbar', 'Work addition submitted. Changes may take a few days to appear.');
+};
+
+const handleRemoveWorks = (workIds) => {
+  console.log('Remove works requested:', workIds);
+  store.commit('snackbar', `Removal of ${workIds.length} work(s) submitted. Changes may take a few days to appear.`);
 };
 
 useHead(() => ({

--- a/src/views/Me/MeProfile.vue
+++ b/src/views/Me/MeProfile.vue
@@ -24,6 +24,8 @@
       </SettingsRow>
     </SettingsSection>
 
+    <AuthorProfileSection />
+
     <SettingsSection title="Account">
       <SettingsRow
         label="Sign out"
@@ -48,6 +50,7 @@ import { useRouter } from 'vue-router';
 import { useHead } from '@unhead/vue';
 import SettingsSection from '@/components/Settings/SettingsSection.vue';
 import SettingsRow from '@/components/Settings/SettingsRow.vue';
+import AuthorProfileSection from '@/components/AuthorProfile/AuthorProfileSection.vue';
 
 defineOptions({ name: 'MeAbout' });
 


### PR DESCRIPTION
Adds author profile claiming, display name editing, works management (add/remove), and CV upload parsing — all gated behind the `author_curation` feature flag so existing UX is unchanged when the flag is off.

New components:
- AuthorCuration/: AddWorksDialog, AddWorksSearch, AddWorksCVUpload, AuthorDisplayNameEditor, AuthorFullNameEditor, AuthorWorksList
- AuthorProfile/: AuthorProfileSection, AuthorProfileClaimed, AuthorProfileSearch, AuthorProfileSearchResult

Modified files:
- apiConfig.js: add cvParseApi URL
- EntityHeader.vue: add #after-title and #after-header named slots
- EntityPage.vue: author-specific layout with curation controls
- MeProfile.vue: add AuthorProfileSection for profile claiming
- AdminExperimental.vue: add UI_DEFINED_FLAGS with author_curation
- user.store.js: add setAuthorIdDirect mutation