### PR TITLE
Escape raw affiliation exact filter values in works preview

### DIFF
--- a/src/__tests__/exactFilter.test.js
+++ b/src/__tests__/exactFilter.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { quoteExactFilterValue } from '../utils/exactFilter';
+
+describe('quoteExactFilterValue', () => {
+  it('wraps a plain value in double quotes', () => {
+    expect(quoteExactFilterValue('SLUB Dresden')).toBe('"SLUB Dresden"');
+  });
+
+  it('preserves operator-like characters inside the quoted value', () => {
+    expect(quoteExactFilterValue('A | B, C*D')).toBe('"A | B, C*D"');
+  });
+
+  it('escapes embedded double quotes as \\"', () => {
+    expect(
+      quoteExactFilterValue('Universitätsbibliothek "Georgius Agricola"')
+    ).toBe('"Universitätsbibliothek \\"Georgius Agricola\\""');
+  });
+
+  it('escapes backslashes as \\\\ before escaping quotes', () => {
+    expect(quoteExactFilterValue('path\\to\\thing')).toBe('"path\\\\to\\\\thing"');
+    expect(quoteExactFilterValue('he said \\"hi\\"')).toBe('"he said \\\\\\"hi\\\\\\""');
+  });
+
+  it('coerces non-string values', () => {
+    expect(quoteExactFilterValue(42)).toBe('"42"');
+  });
+});

--- a/src/components/AffiliationMatchingPanel.vue
+++ b/src/components/AffiliationMatchingPanel.vue
@@ -293,6 +293,7 @@ import { useRoute, useRouter } from 'vue-router';
 import { useStore } from 'vuex';
 import axios from 'axios';
 import { urlBase, axiosConfig } from '@/apiConfig';
+import { quoteExactFilterValue } from '@/utils/exactFilter';
 import RasWorksDialog from './RasWorksDialog.vue';
 
 defineOptions({ name: 'AffiliationMatchingPanel' });
@@ -430,7 +431,7 @@ function getWorksSearchUrl(rasText) {
   // Use quotes around the RAS to preserve commas in the filter value
   // Include is_xpac:true|false to show ALL works (the API defaults to
   // is_xpac:false, but our dashboard counts include xpac works)
-  const encodedRas = encodeURIComponent(`"${rasText}"`);
+  const encodedRas = encodeURIComponent(quoteExactFilterValue(rasText));
   return `/works?filter=raw_affiliation_strings:${encodedRas},is_xpac:true|false`;
 }
 

--- a/src/components/RasWorksDialog.vue
+++ b/src/components/RasWorksDialog.vue
@@ -95,6 +95,7 @@ import { ref, watch, nextTick, onBeforeUnmount } from 'vue';
 import { useStore } from 'vuex';
 import axios from 'axios';
 import { urlBase, axiosConfig } from '@/apiConfig';
+import { quoteExactFilterValue } from '@/utils/exactFilter';
 
 defineOptions({ name: 'RasWorksDialog' });
 
@@ -172,7 +173,7 @@ async function fetchWorks(pageNum) {
   errorMsg.value = null;
 
   try {
-    const encodedRas = encodeURIComponent(`"${props.rasText}"`);
+    const encodedRas = encodeURIComponent(quoteExactFilterValue(props.rasText));
     const url = `${urlBase.api}/works?filter=raw_affiliation_strings:${encodedRas},is_xpac:true|false&select=id,doi,title,publication_year,primary_location&per_page=25&page=${pageNum}&mailto=ui@openalex.org`;
 
     const response = await axios.get(url, axiosConfig());

--- a/src/utils/exactFilter.js
+++ b/src/utils/exactFilter.js
@@ -1,0 +1,10 @@
+/**
+ * Wrap a value in outer double quotes for use as an exact OpenAlex filter
+ * value, escaping embedded backslashes as \\ and embedded double quotes as \".
+ *
+ * The result is NOT URL-encoded — pass it through encodeURIComponent before
+ * embedding it in a query string.
+ */
+export function quoteExactFilterValue(value) {
+  return `"${String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}


### PR DESCRIPTION
Previously, the Affiliation Linking works preview interpolated raw affiliation strings directly into an exact
`raw_affiliation_strings:"..."` filter. Strings containing embedded `"` or `\` could produce ambiguous or invalid
filters once parsed.

This adds a small exact-filter quoting helper in `src/utils/exactFilter.js` and uses it for the raw affiliation
works preview URLs in:

- `RasWorksDialog.vue`
- `AffiliationMatchingPanel.vue`

Embedded backslashes and double quotes are escaped before URL encoding. Operator-like characters such as `|`, `,`,
and `*` are preserved inside the quoted value.

This intentionally keeps the preview as an exact `raw_affiliation_strings` filter.

### Dependency

Depends on https://github.com/ourresearch/openalex-elastic-api/pull/16, which makes quoted exact filter values literal and supports escaped quotes/backslashes.

Merge and deploy the API change first; this PR is safe to merge afterward.

### Verification

```bash
npm run test:run -- src/__tests__/exactFilter.test.js
npm run build
```
