### PR TITLE
#191.5 Fix: don't extra-quote .search filter values (browser proximity/quoted-phrase regression)

### DIFF
--- a/src/__tests__/filterConfigs.test.js
+++ b/src/__tests__/filterConfigs.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import {
+    createSimpleFilter,
+    filtersFromUrlStr,
+    filtersAsUrlStr,
+} from '../filterConfigs';
+
+// Regression coverage for #191.5: createSimpleFilter must not double-quote
+// `.search`-type filter values. Their value is a raw API query string that
+// may already contain quotes / proximity (`~N`) / Boolean groups (`|`/`+`);
+// wrapping it in another pair of `"` corrupts the query (commit c8e689f7).
+describe('filterConfigs — search-filter quoting (#191.5)', () => {
+    it('does NOT extra-quote a .search value containing quotes + proximity', () => {
+        const value = '"Girls perspective"~2|"Girls experience"~2';
+        const f = createSimpleFilter('works', 'title.search', value, false);
+        expect(f.asStr).toBe(`title.search:${value}`);
+        // specifically: no leading double-quote-wrap
+        expect(f.asStr).not.toContain('title.search:""');
+    });
+
+    it('does NOT quote a bare multi-word .search value (loose AND, the API default)', () => {
+        const f = createSimpleFilter('works', 'title.search', 'machine learning', false);
+        expect(f.asStr).toBe('title.search:machine learning');
+    });
+
+    it('round-trips a proximity/quoted .search filter idempotently', () => {
+        const url = 'title.search:"a b"~2|"c d"~2';
+        const filters = filtersFromUrlStr('works', url);
+        expect(filtersAsUrlStr(filters)).toBe(url);
+    });
+
+    it('round-trips the reporter\'s exact 5-clause query unchanged', () => {
+        const url = 'title.search:"Girls perspective"~2|"Girls experience"~2|"Girls attitude"~2|"Girls attitudinal"~2|"Girls belief"~2';
+        const filters = filtersFromUrlStr('works', url);
+        expect(filtersAsUrlStr(filters)).toBe(url);
+    });
+
+    // Regression guard for c8e689f7's original, still-valid case: a
+    // non-`.search` filter value containing a space MUST stay quoted for the
+    // API (e.g. a source type "ebook platform" → type:"ebook platform").
+    it('still quotes a space-containing NON-search filter value', () => {
+        const f = createSimpleFilter('sources', 'type', 'ebook platform', false);
+        expect(f.asStr).toBe('type:"ebook platform"');
+    });
+});

--- a/src/filterConfigs.js
+++ b/src/filterConfigs.js
@@ -246,7 +246,13 @@ const createSimpleFilter = function (entityType, key, value, isNegated) {
     const negationSymbol = (isNegated && !!myValue) ?
         "!" :
         ""
-    const quotedValue = (typeof apiValue === "string" && apiValue.includes(" ")) ? `"${apiValue}"` : apiValue
+    // Wrap space-containing values in quotes for API compatibility (e.g. an
+    // institution display-name select filter). EXCEPT `.search`-type filters:
+    // their value is a raw API query string that may already contain quotes,
+    // proximity (`~N`), or Boolean groups (`|`/`+`). Wrapping those would
+    // double-quote the query and corrupt it (regression c8e689f7 → #191.5).
+    const isSearchFilter = facetConfig.type === "search"
+    const quotedValue = (typeof apiValue === "string" && apiValue.includes(" ") && !isSearchFilter) ? `"${apiValue}"` : apiValue
     const asStr = facetConfig.key + ":" + negationSymbol + quotedValue
 
     return {


### PR DESCRIPTION
## Problem

Browser filter queries using proximity or quoted phrases on `.search` filters (e.g. `title.search:"Girls perspective"~2|...`) silently return wrong counts or HTTP 500. **Regression** introduced by c8e689f7 (2026-03-25); live on prod via auto-deploy since then. Reported by a UCL systematic-review user (oxjob #191 / Case 4).

## Root cause

`createSimpleFilter` (filterConfigs.js) wraps **any** space-containing value in `"`. c8e689f7 added this for non-search filters (e.g. `type:"ebook platform"`) and is correct there. But `.search` values are raw API query strings that may already contain `"`, proximity `~N`, or Boolean `|`/`+`. Wrapping double-quotes them → `title.search:""Girls perspective"~2|..."` → corrupt. The matching unwrap guard in `createFilterValue` sits *after* the `type === "search"` early-return, so search values are wrapped but never unwrapped.

Empirical (prod): single clause 8 results vs 191 intended; reporter's exact 5-clause → HTTP 500.

## Fix

Gate the quote-wrap on `facetConfig.type !== "search"`. Non-search behavior unchanged. Adds `filterConfigs.test.js` (5 tests): round-trip idempotency for proximity/quoted `.search` filters + a guard that c8e689f7's `type:"ebook platform"` case still quotes. New tests fail 4/5 on pre-fix code, 5/5 post-fix. Full suite: 126 pass (8 pre-existing dedup-integration network 404s, unrelated).

## @kyle review

You authored c8e689f7 — please sanity-check that gating by filter type doesn't miss a non-search case you intended to cover. Test 'still quotes a space-containing NON-search filter value' guards `type:"ebook platform"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)