### PR TITLE
UI-provenance token: send X-OpenAlex-UI on API calls (oxjob #338 P-A, GUI)

### DIFF
--- a/src/apiConfig.js
+++ b/src/apiConfig.js
@@ -77,6 +77,21 @@ const axiosConfig = (options={}) => {
         } catch (e) {
             // Store not yet initialized, no API key header
         }
+
+        // UI-provenance token (oxjob #338 Phase 5a): an unforgeable "this came
+        // from the real openalex.org GUI" marker, replacing the spoofable
+        // mailto=ui@openalex.org. Attached when available; absence is harmless
+        // (the API never gates on it — it only sets the analytics trustedUi
+        // tag). Lazy-require mirrors the store import to avoid a circular dep.
+        try {
+            const { getUiToken } = require('@/uiProvenance');
+            const uiToken = getUiToken();
+            if (uiToken) {
+                headers['X-OpenAlex-UI'] = uiToken;
+            }
+        } catch (e) {
+            // Provenance not ready / not initialised — proceed without it.
+        }
     }
 
     if (options.noCache) {
@@ -93,9 +108,17 @@ const axiosConfig = (options={}) => {
 // scoped to openalex.org / www.openalex.org / localhost.
 const TURNSTILE_SITEKEY = "0x4AAAAAADWJQhGbvZ87EmhX";
 
+// Cloudflare Turnstile sitekey for the UI-provenance token (oxjob #338 Phase 5a).
+// Separate widget from signup (independent secret/rotation). Public value;
+// paired secret = openalex-api-proxy Worker secret TURNSTILE_SECRET. Scoped to
+// openalex.org / www.openalex.org (NOT localhost — local dev gets no token and
+// is simply tagged untrusted, which is harmless).
+const UI_PROVENANCE_SITEKEY = "0x4AAAAAADgYVjKGNQI_Wrxm";
+
 export {
     urlBase,
     axiosConfig,
     DISABLE_SERVER_CACHE,
     TURNSTILE_SITEKEY,
+    UI_PROVENANCE_SITEKEY,
 };

--- a/src/main.js
+++ b/src/main.js
@@ -71,3 +71,9 @@ app.config.globalProperties.config = {};
 window.OpenAlex = app;
 
 app.mount('#app');
+
+// UI-provenance token (oxjob #338 Phase 5a): mint an unforgeable "real GUI"
+// marker for OpenAlex API calls, replacing the spoofable mailto. Fire-and-
+// forget — never blocks startup; absence just means requests are tagged
+// untrusted server-side (the API never gates on it).
+import('@/uiProvenance').then(({ initUiProvenance }) => initUiProvenance());

--- a/src/uiProvenance.js
+++ b/src/uiProvenance.js
@@ -1,0 +1,115 @@
+// UI-provenance token manager (oxjob #338 Phase 5a / "P-A").
+//
+// Gives openalex.org API calls an *unforgeable* "this came from the real web
+// GUI" marker, replacing the trivially-spoofable `mailto=ui@openalex.org` query
+// param (bots copy that string verbatim, poisoning the UI-vs-API analytics
+// split #338 and #340 both rely on).
+//
+// Flow: on app start we render an invisible Cloudflare Turnstile widget, swap
+// the Turnstile solve for a short-TTL HMAC token from `POST /ui-token`, hold it
+// in memory, and re-mint shortly before it expires. `axiosConfig()` attaches it
+// as the `X-OpenAlex-UI` header on OpenAlex API calls.
+//
+// DESIGN INVARIANTS:
+// - Provenance, not auth: the API NEVER gates on this token. Every failure path
+//   here (script not loaded, off-domain, challenge unsolved, mint error) just
+//   means "no token" → requests go out untagged → tagged untrusted server-side.
+//   Nothing here may ever block, delay, or break an API call. It's best-effort.
+// - Fully async / fire-and-forget: never awaited by the render path.
+
+import axios from 'axios';
+import { urlBase, UI_PROVENANCE_SITEKEY } from '@/apiConfig';
+
+let _token = null;        // current minted token (or null)
+let _expiresAtMs = 0;     // epoch ms when _token expires
+let _widgetId = null;     // Turnstile widget id
+let _initialized = false; // guard against double-init
+let _remintTimer = null;
+
+// Re-mint this many ms before expiry so a valid token is (almost) always ready.
+const REMINT_LEAD_MS = 60_000;
+
+/** Synchronous getter used by axiosConfig(). Returns a non-expired token or null. */
+export function getUiToken() {
+    if (_token && Date.now() < _expiresAtMs) return _token;
+    return null;
+}
+
+// The Turnstile script (public/index.html) is async; window.turnstile may not
+// exist yet. Poll up to ~5s, matching useTurnstile.js.
+async function ensureTurnstileLoaded() {
+    for (let i = 0; i < 50; i++) {
+        if (window.turnstile) return true;
+        await new Promise((r) => setTimeout(r, 100));
+    }
+    return false;
+}
+
+// Exchange a Turnstile solve for a minted UI-provenance token.
+async function mintFromTurnstile(turnstileResponse) {
+    try {
+        const res = await axios.post(
+            `${urlBase.api}/ui-token`,
+            { turnstileResponse },
+            { headers: { 'Content-Type': 'application/json' } },
+        );
+        const token = res?.data?.token;
+        const expiresIn = res?.data?.expiresIn; // seconds
+        if (token && expiresIn) {
+            _token = token;
+            _expiresAtMs = Date.now() + expiresIn * 1000;
+            scheduleRemint(expiresIn * 1000);
+        }
+    } catch (e) {
+        // Mint not configured (503), Turnstile rejected (403), or network error.
+        // Harmless — we simply have no token this cycle.
+        _token = null;
+        _expiresAtMs = 0;
+    }
+}
+
+// Force a fresh Turnstile solve (its token is short-lived/single-use), which
+// triggers the render callback → mintFromTurnstile.
+function refreshTurnstile() {
+    if (_widgetId !== null && window.turnstile) {
+        try { window.turnstile.reset(_widgetId); } catch { /* ignore */ }
+    }
+}
+
+function scheduleRemint(ttlMs) {
+    if (_remintTimer) clearTimeout(_remintTimer);
+    const delay = Math.max(ttlMs - REMINT_LEAD_MS, 5_000);
+    _remintTimer = setTimeout(refreshTurnstile, delay);
+}
+
+/**
+ * Initialise UI provenance. Call once at app startup. Never throws, never
+ * blocks — safe to call fire-and-forget.
+ */
+export async function initUiProvenance() {
+    if (_initialized) return;
+    _initialized = true;
+    try {
+        const ready = await ensureTurnstileLoaded();
+        if (!ready) return; // no Turnstile → no token; harmless
+
+        // Headless: render into a hidden, body-attached anchor (no component).
+        const anchor = document.createElement('div');
+        anchor.className = 'ui-provenance-turnstile';
+        anchor.style.position = 'fixed';
+        anchor.style.bottom = '0';
+        anchor.style.right = '0';
+        anchor.style.zIndex = '2147483647'; // above all, in case CF surfaces a challenge
+        document.body.appendChild(anchor);
+
+        _widgetId = window.turnstile.render(anchor, {
+            sitekey: UI_PROVENANCE_SITEKEY,
+            appearance: 'interaction-only', // invisible unless CF promotes to interactive
+            callback: (turnstileResponse) => { mintFromTurnstile(turnstileResponse); },
+            'error-callback': () => { /* leave _token as-is; retry on next remint */ },
+            'expired-callback': () => { refreshTurnstile(); },
+        });
+    } catch (e) {
+        // Any failure here must not affect the app.
+    }
+}


### PR DESCRIPTION
GUI side of the unforgeable UI-provenance marker. Pairs with **openalex-api-proxy#2** (merge that first so `/ui-token` exists).

## What
- `src/uiProvenance.js` — headless, app-global token manager: renders an invisible Turnstile widget (dedicated sitekey `0x4AAAAAADgYVjKGNQI_Wrxm`), swaps the solve for a 30-min token via `POST /ui-token`, re-mints before expiry.
- `src/apiConfig.js` — `axiosConfig()` attaches `X-OpenAlex-UI` on OpenAlex API calls when a token is available.
- `src/main.js` — fire-and-forget `initUiProvenance()` after mount.

## Safety
- **Best-effort, never blocks.** Every failure path (script not loaded, off-domain, challenge unsolved, mint 503/403, network error) just yields no token → requests go out untagged → tagged untrusted server-side. Nothing here can block, delay, or break an API call or app startup.
- **Dual-run.** `mailto=ui@openalex.org` is still emitted; deprecate only once the `trustedUi` analytics series is healthy.
- **Local dev** gets no token (sitekey scoped to openalex.org/www, not localhost) — harmless.

## Deploy ordering
Merge `openalex-api-proxy#2` first (so `/ui-token` is live), then this. Reverse order is still safe (GUI just gets 503 → no token until the proxy ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)